### PR TITLE
Add support for .toPandas() from external libs

### DIFF
--- a/kensu/utils/dsl/extractors/__init__.py
+++ b/kensu/utils/dsl/extractors/__init__.py
@@ -36,7 +36,7 @@ class Extractors(object):
     def __init__(self, ):
         self.supports = []
 
-    def add_default_supports(self, pandas_support=True, sklearn_support=True, numpy_support=True, tensorflow_support=False, bigquery_support=False):
+    def add_default_supports(self, pandas_support=True, sklearn_support=True, numpy_support=True, tensorflow_support=False, bigquery_support=False, generic_datasource_info_support=True):
         if pandas_support:
             from kensu.pandas.extractor import KensuPandasSupport
             self.add_support(KensuPandasSupport())
@@ -52,6 +52,10 @@ class Extractors(object):
         if bigquery_support:
             from kensu.google.cloud.bigquery.extractor import KensuBigQuerySupport
             self.add_support(KensuBigQuerySupport())
+
+        if generic_datasource_info_support:
+            from kensu.utils.dsl.extractors.generic_datasource_info_support import GenericDatasourceInfoSupport
+            self.add_support(GenericDatasourceInfoSupport())
 
 
 

--- a/kensu/utils/dsl/extractors/external_lineage_dtos.py
+++ b/kensu/utils/dsl/extractors/external_lineage_dtos.py
@@ -1,0 +1,41 @@
+class KensuDatasourceAndSchema:
+    def __init__(self,
+                 ksu_ds,
+                 ksu_schema,
+                 f_get_stats=lambda: {}):
+        """
+        :param kensu.client.DataSource ksu_ds: Datasource info which was extracted from external system
+        :param kensu.client.Schema ksu_schema: Schema info for the datasource
+        :param () -> typing.Dict[string, float] f_get_stats: [Optional] a function to retrieve DataStats for this DataSource
+        """
+        self.ksu_ds = ksu_ds
+        self.ksu_schema = ksu_schema
+        # this allows expensive delaying computation of stats until they are needed (if at all)
+        self.f_get_stats = f_get_stats
+
+
+class ExtDependencyEntry:
+    def __init__(
+            self,
+            input_ds,  # type: KensuDatasourceAndSchema
+            # {out_column: [input_column1, input_column2, ...]}
+            lineage=None  # type: dict[str, list[str]]
+    ):
+        """
+        :param KensuDatasourceAndSchema input_ds:
+        :param typing.Dict[str, typing.List[str]]  lineage: format is  `{out_column: [input_column1, input_column2, ...]}`
+        """
+        self.input_ds = input_ds
+        if lineage is None:
+            lineage = {}
+        self.lineage = lineage
+
+
+class GenericComputedInMemDs:
+    def __init__(
+            self,
+            inputs,  # type: list[KensuDatasourceAndSchema]
+            lineage  # type: list[ExtDependencyEntry]
+    ):
+        self.lineage = lineage
+        self.inputs = inputs

--- a/kensu/utils/dsl/extractors/generic_datasource_info_support.py
+++ b/kensu/utils/dsl/extractors/generic_datasource_info_support.py
@@ -1,0 +1,40 @@
+from kensu.utils.dsl.extractors import ExtractorSupport
+from kensu.utils.helpers import singleton
+
+from kensu.utils.dsl.extractors.external_lineage_dtos import KensuDatasourceAndSchema
+
+
+@singleton
+class GenericDatasourceInfoSupport(ExtractorSupport):  # should extends some DamSupport class
+
+    def is_supporting(self, df):
+        return isinstance(df, KensuDatasourceAndSchema)
+
+    def is_machine_learning(self, df):
+        return False
+
+    # return dict of doubles (stats)
+    # stats are reported inside spark itself (?)
+    def extract_stats(self, df):
+        print('starting waiting for datastats for {}'.format(df.ksu_ds.name))
+        stats = df.f_get_stats()
+        print('done waiting for datastats for {}'.format(df.ksu_ds.name))
+        return stats
+
+    def extract_data_source(self,
+                            ds,  # type: KensuDatasourceAndSchema
+                            pl,
+                            **kwargs):
+        return ds.ksu_ds
+
+    def extract_schema(
+            self,
+            data_source,
+            df  # type: KensuDatasourceAndSchema
+    ):
+        return df.ksu_schema
+
+    def extract_data_source_and_schema(self, df, pl, **kwargs):
+        ds = self.extract_data_source(df, pl, **kwargs)
+        sc = self.extract_schema(ds, df)
+        return ds, sc

--- a/kensu/utils/helpers.py
+++ b/kensu/utils/helpers.py
@@ -23,12 +23,14 @@ def singleton(cls, *args, **kw):
 def to_hash_key(o):
     return sha1(str(o).encode()).hexdigest()
 
+
 def eventually_report_in_mem(o):
     from kensu.utils.kensu_provider import KensuProvider
     kensu = KensuProvider().instance()
     if kensu.report_in_mem:
         o._report()
     return o
+
 
 def get_absolute_path(path):
     import os
@@ -38,3 +40,21 @@ def get_absolute_path(path):
             prefix = prefix.replace('/', '')
             return prefix + ':' + path
     return 'file:' + str(os.path.abspath(path))
+
+
+def maybe_report(o, report):
+    from kensu.utils.kensu_provider import KensuProvider
+    dam = KensuProvider().instance()
+    if report:
+        o._report()
+    return o
+
+
+def extract_ksu_ds_schema(kensu, orig_variable, report=False, register_orig_data=False):
+    ds = kensu.extractors.extract_data_source(orig_variable, kensu.default_physical_location_ref, logical_naming=kensu.logical_naming)
+    schema = kensu.extractors.extract_schema(ds, orig_variable)
+    maybe_report(ds, report=report)
+    maybe_report(schema, report=report)
+    if register_orig_data:
+        kensu.real_schema_df[schema.to_guid()] = orig_variable
+    return ds, schema

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from setuptools import setup, find_packages
 
 NAME = "kensu"
 
-VERSION = "1.3.5.3"
+VERSION = "1.3.6.0"
 
 # To install the library, run the following
 #

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from setuptools import setup, find_packages
 
 NAME = "kensu"
 
-VERSION = "1.3.5.2"
+VERSION = "1.3.5.3"
 
 # To install the library, run the following
 #

--- a/tests/unit/test_external_to_pandas.py
+++ b/tests/unit/test_external_to_pandas.py
@@ -1,0 +1,78 @@
+#  python -m unittest discover -s tests/unit
+
+import logging
+import sys
+import unittest
+
+import kensu.pandas as pd
+from kensu.client import ApiClient
+from kensu.utils.kensu_provider import KensuProvider
+
+log_format = '%(asctime)s %(levelname)s %(filename)s:%(lineno)d %(message)s'
+logging.basicConfig(stream=sys.stdout, level=logging.INFO, format=log_format)
+
+# Below is an example of how easily one could track a lineage of data conversion from an external library into pandas
+# A real world example would be Apache Spark's DataFrame.toPandas() function,
+# here to reduce need of heavy dependency we use a mocked version of such function
+
+
+class FakeSparkDataFrame:
+
+    def toPandas(self):
+        import pandas as pd_orig
+        data = [['tom', 10], ['nick', 15], ['juli', 14]]
+        df = pd_orig.DataFrame(data, columns = ['out_field_name1', 'Age'])
+        return df
+
+
+def get_inputs_lineage_fn(ksu, df):
+    from kensu.utils.dsl.extractors.external_lineage_dtos import KensuDatasourceAndSchema, GenericComputedInMemDs, \
+        ExtDependencyEntry
+    from kensu.client import DataSourcePK, DataSource, FieldDef, SchemaPK, Schema
+    pl_ref = ksu.UNKNOWN_PHYSICAL_LOCATION.to_ref()
+    ds_pk = DataSourcePK(location="hdfs://namenode/dataset1/partition1/file1.parquet", physical_location_ref=pl_ref)
+    ds = DataSource(name="file1.parquet", format="parquet", categories=['logical::dataset1'], pk=ds_pk)
+    fields = [
+        FieldDef(name=str("in1"), field_type="string", nullable=True),
+        FieldDef(name=str("in2"), field_type="string", nullable=True),
+    ]
+    schema = Schema(name="schema:" + ds.name,
+                    pk=SchemaPK(ds.to_ref(), fields=fields))
+    lineage_info = [ExtDependencyEntry(
+        input_ds=KensuDatasourceAndSchema(ksu_ds=ds, ksu_schema=schema, f_get_stats=lambda: {'in1.max': 123.12}),
+        lineage={
+            "out_field_name1": ["in1", "in2"],
+            "Age": ["in2"]
+
+        })]
+    return GenericComputedInMemDs(inputs=list([x.input_ds for x in lineage_info]), lineage=lineage_info)
+
+
+def patch_external_transformation():
+    print('patching FakeDataFrame.toPandas')
+    FakeSparkDataFrame.toPandas = pd.data_frame.wrap_external_to_pandas_transformation(
+        FakeSparkDataFrame.toPandas,
+        get_inputs_lineage_fn
+    )
+    print('done patching FakeDataFrame.toPandas')
+
+
+class TestExternalToPandas(unittest.TestCase):
+    offline = True
+    kensu = KensuProvider().initKensu(init_context=True,
+                                      report_to_file=offline,
+                                      offline_file_name='kensu-offline-to-pandas-test.jsonl',
+                                      mapping=True, report_in_mem=True)
+
+    def setUp(self):
+        self.ac = ApiClient()
+        patch_external_transformation()
+
+    def test_one(self):
+        FakeSparkDataFrame().\
+            toPandas()\
+            .to_csv('fake_spark_to_pandas_out')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Add generic datasource abstractions:
- `KensuDatasourceAndSchema` - also contains a method to get datastats on demand
- `GenericComputedInMemDs` - for now this is the thing to store/transfer lineage info of `pandas.DataFrame` which was created for external source, like spark DataFrame with `.toPandas()` method. might be renamed later. 
  * P.S. in `sparkDf.toPandas()` wrapper fn we return earlier existing pandas dataframe wrapper (GenericComputedInMemDs is just a data transfer object from spark to python modules)
-  `GenericDatasourceInfoSupport` - schema/datasource/datastats extractor for `KensuDatasourceAndSchema`