### PR TITLE
use random uuid instead of sha(pandas) to speedup

### DIFF
--- a/kensu/numpy/extractor.py
+++ b/kensu/numpy/extractor.py
@@ -4,7 +4,7 @@ import numpy
 
 import kensu
 from kensu.client import FieldDef, SchemaPK, Schema, DataSource, DataSourcePK
-from kensu.utils.dsl.extractors import ExtractorSupport
+from kensu.utils.dsl.extractors import ExtractorSupport, get_or_set_rand_location
 from kensu.utils.helpers import singleton
 
 @singleton
@@ -33,13 +33,13 @@ class ndarraySupport(ExtractorSupport):  # should extends some KensuSupport clas
                 d.append(FieldDef(name=key, field_type=str(item[0]), nullable=True))
             return d
 
-
     def extract_location(self, nd, location):
         if location is not None:
             return location
         else:
             nd = self.skip_wr(nd)
-            return "in-mem://AN_ID" + sha256(str(nd.tolist()).encode("utf-8")).hexdigest()
+            # FIXME: or should it be added as prop to the ksu wrapper instead?!
+            return get_or_set_rand_location(nd)
 
     def extract_format(self, nd, fmt):
         if fmt is not None:

--- a/kensu/pandas/extractor.py
+++ b/kensu/pandas/extractor.py
@@ -5,7 +5,7 @@ import numpy as np
 
 import kensu
 from kensu.client import *
-from kensu.utils.dsl.extractors import ExtractorSupport
+from kensu.utils.dsl.extractors import ExtractorSupport, get_or_set_rand_location
 from kensu.utils.helpers import singleton
 
 @singleton
@@ -45,8 +45,8 @@ class KensuPandasSupport(ExtractorSupport):  # should extends some KensuSupport 
             from kensu.pandas import DataFrame
             if isinstance(df,DataFrame):
                 df = df.get_df()
-            return "in-mem://AN_ID" + sha256(str(df.reset_index().to_dict()).encode("utf-8")).hexdigest() +'/in-mem-transformation'
-            
+            # FIXME: or should it be added as prop to the ksu wrapper instead?!
+            return get_or_set_rand_location(df)
 
     def extract_format(self, df, fmt):
         if fmt is not None:

--- a/kensu/utils/dsl/extractors/__init__.py
+++ b/kensu/utils/dsl/extractors/__init__.py
@@ -1,5 +1,16 @@
 from kensu.utils.helpers import singleton
 
+import uuid
+
+
+def get_or_set_rand_location(obj):
+    if hasattr(obj, '_ksu_loc_id'):
+        return obj._ksu_loc_id
+    else:
+        new_id = "in-mem://AN_ID" + str(uuid.uuid4()) + '/in-mem-transformation'
+        obj._ksu_loc_id = new_id
+        return new_id
+
 
 class ExtractorSupport(object):
     def is_supporting(self, value):

--- a/kensu/utils/kensu.py
+++ b/kensu/utils/kensu.py
@@ -100,7 +100,7 @@ class Kensu(object):
         self.extractors = Extractors()
         pandas_support = kwargs_or_conf_or_default("pandas_support", True)
         sklearn_support = kwargs_or_conf_or_default("sklearn_support", True)
-        bigquery_support = kwargs_or_conf_or_default("bigquery_support", True)
+        bigquery_support = kwargs_or_conf_or_default("bigquery_support", False)
         tensorflow_support = kwargs_or_conf_or_default("tensorflow_support", True)
         self.extractors.add_default_supports(pandas_support=pandas_support, sklearn_support=sklearn_support,bigquery_support=bigquery_support,tensorflow_support=tensorflow_support)
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from setuptools import setup, find_packages
 NAME = "kensu"
 
 
-VERSION = "1.4.0.1"
+VERSION = "1.4.1.0"
 
 
 # To install the library, run the following


### PR DESCRIPTION
for 4M rows speed up from 5minutes in say `ksu_pandas_df.fillna()` -> ~0.2s, expect larger speed for more rows (like 2h-> seconds)

still need to test if lineage is still correct...


Sort of Related issues:

- [ ] displaying kensu pandas wrapper is slow for large pandas DSes with many rows (while original pandas is fast)