### PR TITLE
Track Requests & S3 put

### DIFF
--- a/kensu/boto3/__init__.py
+++ b/kensu/boto3/__init__.py
@@ -1,26 +1,47 @@
 import boto3
 from boto3 import *
 
+from kensu.client import DataSourcePK, DataSource, FieldDef, SchemaPK, Schema
 from kensu.requests.models import ksu_str
+from kensu.utils.kensu_provider import KensuProvider
 
 
 def kensu_put(event_params, event_ctx, **kwargs):
     if isinstance(event_params.get('Body'), ksu_str):
+        kensu = KensuProvider().instance()
         put_body = event_params.get('Body')
         #The input is the ksu_str, the metadata contains its schema pk
         input_schema = put_body.metadata['schema']
         input_location = put_body.metadata['ds_location']
         s3_bucket = event_params.get('Bucket') or 'unknown-s3-bucket'
         s3_key = event_params.get('Key') or 'unknown-s3-key'
-        from kensu.utils.dsl.extractors.external_lineage_dtos import GenericComputedInMemDs
-        GenericComputedInMemDs.report_copy_with_opt_schema(
-            src=input_location,
-            src_name=None,
-            dest='aws::S3::' + s3_bucket + '/' + s3_key,  # output datasource (stored in S3)
-            dest_name=s3_key,
-            operation_type="s3.put()",
-            maybe_schema=[(f.name, f.field_type) for f in input_schema.pk.fields]
-        )
+
+        # Creation of the output datasource (stored in S3)
+        location = 'aws::S3::' + s3_bucket + '/' + s3_key
+        name = s3_key
+
+        result_pk = DataSourcePK(location=location,
+                                 physical_location_ref=kensu.default_physical_location_ref)
+        result_ds = DataSource(name=name, format=name.split('.')[-1],
+                               pk=result_pk)._report()
+
+        input_fields = [k.name for k in input_schema.pk.fields]
+        input_schema_pk = input_schema.to_guid()
+
+        # This data source has the same schema fields as the input
+
+        fields = [FieldDef(name=k.name, field_type=k.field_type, nullable=True) for k in input_schema.pk.fields]
+
+        sc_pk = SchemaPK(result_ds.to_ref(),
+                         fields=fields)
+        result_sc = Schema(name="schema:" + result_ds.name, pk=sc_pk)._report()
+
+        kensu.real_schema_df[result_sc.to_guid()] = put_body.metadata['stats']
+
+        for col in input_fields:
+            kensu.add_dependencies_mapping(result_sc.to_guid(),str(col),input_schema_pk,str(col),'s3_put')
+        kensu.report_with_mapping()
+
 
 def add_custom_method(class_attributes, **kwargs):
     class_attributes['kensu_put'] = kensu_put

--- a/kensu/boto3/__init__.py
+++ b/kensu/boto3/__init__.py
@@ -1,8 +1,49 @@
 import boto3
+from boto3 import *
+
+from kensu.client import DataSourcePK, DataSource, Schema, SchemaPK, FieldDef
+from kensu.utils.kensu_provider import KensuProvider
+from kensu.requests.models import ksu_str
+from kensu.utils.helpers import eventually_report_in_mem
+
 
 def kensu_put(self,**kwargs):
     self.put(**kwargs)
-    print('This is my custom method'+str(kwargs))
+
+    if isinstance(kwargs['Body'], ksu_str):
+        #The input is the ksu_str, the metadata contains its schema pk
+
+        input_schema = kwargs['Body'].metadata['schema']
+        input_location = kwargs['Body'].metadata['ds_location']
+
+        #Creation of the output datasource (stored in S3)
+        location = 'aws::S3::' + self.bucket_name + '/' + self.key
+        name = self.key
+
+        kensu = KensuProvider().instance()
+
+        result_pk = DataSourcePK(location=location,
+                                 physical_location_ref=kensu.default_physical_location_ref)
+        result_ds = DataSource(name=name, format=name.split('.')[-1],
+                               pk=result_pk)._report()
+
+        # This data source has the same schema fields as the input
+
+        fields = [FieldDef(name=k.name,field_type=k.field_type,nullable=True) for k in input_schema.pk.fields]
+
+        sc_pk = SchemaPK(result_ds.to_ref(),
+                         fields=fields)
+        result_sc = Schema(name="schema:" + result_ds.name, pk=sc_pk)._report()
+
+        kensu.real_schema_df[result_sc.to_guid()] = None
+
+        from kensu.utils.dsl.extractors.external_lineage_dtos import GenericComputedInMemDs
+        GenericComputedInMemDs.report_copy_with_opt_schema(
+            src=input_location,
+            dest=location,
+            operation_type="s3.put()",
+            maybe_schema=[(f.name, f.field_type) for f in input_schema.pk.fields]
+        )
 
 def add_custom_method(class_attributes, **kwargs):
     class_attributes['kensu_put'] = kensu_put

--- a/kensu/boto3/__init__.py
+++ b/kensu/boto3/__init__.py
@@ -1,0 +1,11 @@
+import boto3
+
+def kensu_put(self,**kwargs):
+    self.put(**kwargs)
+    print('This is my custom method'+str(kwargs))
+
+def add_custom_method(class_attributes, **kwargs):
+    class_attributes['kensu_put'] = kensu_put
+
+boto3._get_default_session().events.register("creating-resource-class.s3.Object",
+                        add_custom_method)

--- a/kensu/boto3/__init__.py
+++ b/kensu/boto3/__init__.py
@@ -1,46 +1,23 @@
 import boto3
 from boto3 import *
 
-from kensu.client import DataSourcePK, DataSource, Schema, SchemaPK, FieldDef
-from kensu.utils.kensu_provider import KensuProvider
 from kensu.requests.models import ksu_str
-from kensu.utils.helpers import eventually_report_in_mem
 
 
-def kensu_put(self,**kwargs):
-    self.put(**kwargs)
-
-    if isinstance(kwargs['Body'], ksu_str):
+def kensu_put(event_params, event_ctx, **kwargs):
+    if isinstance(event_params.get('Body'), ksu_str):
+        put_body = event_params.get('Body')
         #The input is the ksu_str, the metadata contains its schema pk
-
-        input_schema = kwargs['Body'].metadata['schema']
-        input_location = kwargs['Body'].metadata['ds_location']
-
-        #Creation of the output datasource (stored in S3)
-        location = 'aws::S3::' + self.bucket_name + '/' + self.key
-        name = self.key
-
-        kensu = KensuProvider().instance()
-
-        result_pk = DataSourcePK(location=location,
-                                 physical_location_ref=kensu.default_physical_location_ref)
-        result_ds = DataSource(name=name, format=name.split('.')[-1],
-                               pk=result_pk)._report()
-
-        # This data source has the same schema fields as the input
-
-        fields = [FieldDef(name=k.name,field_type=k.field_type,nullable=True) for k in input_schema.pk.fields]
-
-        sc_pk = SchemaPK(result_ds.to_ref(),
-                         fields=fields)
-        result_sc = Schema(name="schema:" + result_ds.name, pk=sc_pk)._report()
-
-        kensu.real_schema_df[result_sc.to_guid()] = None
-
+        input_schema = put_body.metadata['schema']
+        input_location = put_body.metadata['ds_location']
+        s3_bucket = event_params.get('Bucket') or 'unknown-s3-bucket'
+        s3_key = event_params.get('Key') or 'unknown-s3-key'
         from kensu.utils.dsl.extractors.external_lineage_dtos import GenericComputedInMemDs
         GenericComputedInMemDs.report_copy_with_opt_schema(
             src=input_location,
-            dest=location,
+            src_name=None,
+            dest='aws::S3::' + s3_bucket + '/' + s3_key,  # output datasource (stored in S3)
+            dest_name=s3_key,
             operation_type="s3.put()",
             maybe_schema=[(f.name, f.field_type) for f in input_schema.pk.fields]
         )
@@ -50,3 +27,33 @@ def add_custom_method(class_attributes, **kwargs):
 
 boto3._get_default_session().events.register("creating-resource-class.s3.Object",
                         add_custom_method)
+
+
+
+def kensu_tracker(*class_attributes, **kwargs):
+    param_types = [
+    ]
+    import pprint
+    if kwargs.get('params'):
+        param_types = [[k, v, type(v)] for k, v in kwargs.get('params').items()]
+    logging.debug('---\nKensu AWS tracker: '
+          'param_types: {}\n'
+          'class_attributes:{}\n kwargs: {}\n-----'.format(
+        str(param_types),
+        str(class_attributes),
+        pprint.pformat(kwargs) + '\n'+ str([ [k, v, type(v)] for k,v in kwargs.items()])))
+
+    event_name = kwargs.get('event_name')
+    event_params = kwargs.get('params')
+    event_ctx = kwargs.get('context')
+    if event_name == 'provide-client-params.s3.PutObject' and event_params:
+        kensu_put(event_params=event_params, event_ctx=event_ctx, **kwargs)
+
+#boto3._get_default_session().events.register('creating-resource-class.s3.ServiceResource',kensu_tracker)
+#boto3._get_default_session().events.register('before-send.s3.PutObject', kensu_tracker)
+boto3._get_default_session().events.register('provide-client-params.s3.PutObject', kensu_tracker)
+
+# in case we wanted to see all events - use *
+# event_system = S3.meta.client.meta.events
+# event_system.register("*",kensu_tracker)
+#event_system.register('creating-resource-class.s3.*', prt)

--- a/kensu/requests/__init__.py
+++ b/kensu/requests/__init__.py
@@ -1,2 +1,3 @@
 from requests import *
 from kensu.requests.api import get
+from kensu.requests.models import Response

--- a/kensu/requests/api.py
+++ b/kensu/requests/api.py
@@ -28,7 +28,16 @@ def wrap_get(method):
         result.__class__ = Response
         result.ksu_schema = result_sc
         result.ds_location = result.url
+        try:
+            import json
+            d = json.loads(result.text)
+            count_json = len(d)
+            stats = {'count':count_json}
+
+        except:
+            stats = None
         kensu.real_schema_df[result_sc.to_guid()] = None
+        result.ksu_stats = stats
 
         return result
 

--- a/kensu/requests/api.py
+++ b/kensu/requests/api.py
@@ -1,6 +1,7 @@
 from kensu.client import DataSourcePK, DataSource, SchemaPK, Schema, FieldDef
 from kensu.utils.kensu_provider import KensuProvider
 from kensu.utils.helpers import eventually_report_in_mem,flatten
+from kensu.requests.models import Response
 
 import requests as req
 
@@ -23,6 +24,11 @@ def wrap_get(method):
                          fields=fields)
 
         result_sc = Schema(name="schema:" + result_ds.name, pk=sc_pk)._report()
+
+        result.__class__ = Response
+        result.ksu_schema = result_sc
+        kensu.real_schema_df[result_sc.to_guid()] = None
+
         return result
 
     wrapper.__doc__ = method.__doc__

--- a/kensu/requests/api.py
+++ b/kensu/requests/api.py
@@ -27,6 +27,7 @@ def wrap_get(method):
 
         result.__class__ = Response
         result.ksu_schema = result_sc
+        result.ds_location = result.url
         kensu.real_schema_df[result_sc.to_guid()] = None
 
         return result

--- a/kensu/requests/models.py
+++ b/kensu/requests/models.py
@@ -1,0 +1,13 @@
+from kensu.pandas import DataFrame,Series
+from kensu.utils.kensu_provider import KensuProvider
+import requests.models as md
+from kensu.utils.helpers import eventually_report_in_mem
+from kensu.numpy import ndarray
+
+
+class Response(md.Response):
+    ksu_schema = None
+
+
+
+

--- a/kensu/requests/models.py
+++ b/kensu/requests/models.py
@@ -12,12 +12,13 @@ class ksu_str(str):
 class Response(md.Response):
 
     ksu_schema = None
+    ksu_stats = None
 
     @property
     def text(self) -> str:
         result = super(Response, self).text
         ksu_result = ksu_str(result)
-        ksu_result.metadata = {"schema":self.ksu_schema, "ds_location":self.ds_location}
+        ksu_result.metadata = {"schema":self.ksu_schema, "ds_location":self.ds_location, "stats":self.ksu_stats}
         return ksu_result
 
 

--- a/kensu/requests/models.py
+++ b/kensu/requests/models.py
@@ -4,10 +4,21 @@ import requests.models as md
 from kensu.utils.helpers import eventually_report_in_mem
 from kensu.numpy import ndarray
 
+import builtins
+# Extended subclass
+class ksu_str(str):
+    ksu_metadata = None
 
 class Response(md.Response):
+
     ksu_schema = None
 
+    @property
+    def text(self) -> str:
+        result = super(Response, self).text
+        ksu_result = ksu_str(result)
+        ksu_result.metadata = {"schema":self.ksu_schema, "ds_location":self.ds_location}
+        return ksu_result
 
 
 

--- a/kensu/utils/dsl/extractors/external_lineage_dtos.py
+++ b/kensu/utils/dsl/extractors/external_lineage_dtos.py
@@ -1,3 +1,6 @@
+import logging
+
+
 class KensuDatasourceAndSchema:
     def __init__(self,
                  ksu_ds,
@@ -27,7 +30,7 @@ class KensuDatasourceAndSchema:
         ds = DataSource(name=ds_path, format=format, categories=categories, pk=ds_pk)
         if maybe_schema is None:
             maybe_schema = [("unknown", "unknown"), ]
-        print(maybe_schema)
+        logging.debug(str(maybe_schema))
         fields = list([
             FieldDef(name=str(name), field_type=str(dtype), nullable=True)
             for (name, dtype) in maybe_schema

--- a/kensu/utils/dsl/extractors/external_lineage_dtos.py
+++ b/kensu/utils/dsl/extractors/external_lineage_dtos.py
@@ -23,11 +23,11 @@ class KensuDatasourceAndSchema:
 
 
     @staticmethod
-    def for_path_with_opt_schema(ksu, ds_path, format=None, categories=None, maybe_schema=None):
+    def for_path_with_opt_schema(ksu, ds_path, format=None, categories=None, maybe_schema=None, ds_name=None):
         from kensu.client import DataSourcePK, DataSource, FieldDef, SchemaPK, Schema
         pl_ref = ksu.UNKNOWN_PHYSICAL_LOCATION.to_ref()
         ds_pk = DataSourcePK(location=ds_path, physical_location_ref=pl_ref)
-        ds = DataSource(name=ds_path, format=format, categories=categories, pk=ds_pk)
+        ds = DataSource(name=ds_name or ds_path, format=format, categories=categories, pk=ds_pk)
         if maybe_schema is None:
             maybe_schema = [("unknown", "unknown"), ]
         logging.debug(str(maybe_schema))
@@ -97,11 +97,11 @@ class GenericComputedInMemDs:
 
 
     @staticmethod
-    def report_copy_with_opt_schema(src, dest, operation_type, maybe_schema=None):
+    def report_copy_with_opt_schema(src, dest, operation_type, maybe_schema=None, dest_name=None, src_name=None):
         from kensu.utils.kensu_provider import KensuProvider
         ksu = KensuProvider().instance()
-        input_ds = KensuDatasourceAndSchema.for_path_with_opt_schema(ksu=ksu, ds_path=src, maybe_schema=maybe_schema)
-        output_ds = KensuDatasourceAndSchema.for_path_with_opt_schema(ksu=ksu, ds_path=dest, maybe_schema=maybe_schema)
+        input_ds = KensuDatasourceAndSchema.for_path_with_opt_schema(ksu=ksu, ds_path=src, maybe_schema=maybe_schema, ds_name=src_name)
+        output_ds = KensuDatasourceAndSchema.for_path_with_opt_schema(ksu=ksu, ds_path=dest, maybe_schema=maybe_schema, ds_name=dest_name)
         if maybe_schema is None:
             maybe_schema = [("unknown", "unknown")]
         lineage_info = [ExtDependencyEntry(

--- a/kensu/utils/dsl/extractors/generic_datasource_info_support.py
+++ b/kensu/utils/dsl/extractors/generic_datasource_info_support.py
@@ -1,3 +1,5 @@
+import logging
+
 from kensu.utils.dsl.extractors import ExtractorSupport
 from kensu.utils.helpers import singleton
 
@@ -16,9 +18,9 @@ class GenericDatasourceInfoSupport(ExtractorSupport):  # should extends some Dam
     # return dict of doubles (stats)
     # stats are reported inside spark itself (?)
     def extract_stats(self, df):
-        print('starting waiting for datastats for {}'.format(df.ksu_ds.name))
+        logging.debug('starting waiting for datastats for {}'.format(df.ksu_ds.name))
         stats = df.f_get_stats()
-        print('done waiting for datastats for {}'.format(df.ksu_ds.name))
+        logging.debug('done waiting for datastats for {}'.format(df.ksu_ds.name))
         return stats
 
     def extract_data_source(self,

--- a/kensu/utils/helpers.py
+++ b/kensu/utils/helpers.py
@@ -1,9 +1,6 @@
 import re
 from hashlib import sha1
 
-import pandas as pd
-
-
 def to_snake_case(name):
     s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
     return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()

--- a/kensu/utils/helpers.py
+++ b/kensu/utils/helpers.py
@@ -1,6 +1,9 @@
 import re
 from hashlib import sha1
 
+import pandas as pd
+
+
 def to_snake_case(name):
     s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
     return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()
@@ -59,14 +62,19 @@ def extract_ksu_ds_schema(kensu, orig_variable, report=False, register_orig_data
 
 def flatten(d, parent_key='', sep='.'):
     items = []
-    for k, v in d.items():
-        new_key = parent_key + sep + k if parent_key else k
-        if isinstance(v, dict):
-            items.extend(flatten(v, new_key, sep=sep).items())
-        elif isinstance(v, list):
-            new_key = new_key + '[]'
-            for i in v:
-                items.extend(flatten(i, new_key, sep=sep).items())
-        else:
-            items.append((new_key, type(v).__name__))
+    if isinstance(d,list):
+        for element in d:
+            items.extend(flatten(element, parent_key='[]', sep=sep).items())
+    else:
+        for k, v in d.items():
+            new_key = parent_key + sep + k if parent_key else k
+            if isinstance(v, dict):
+                items.extend(flatten(v, new_key, sep=sep).items())
+            elif isinstance(v, list):
+                if isinstance(v[0], dict):
+                    new_key = new_key + '[]'
+                    for i in v:
+                        items.extend(flatten(i, new_key, sep=sep).items())
+            else:
+                items.append((new_key, type(v).__name__))
     return dict(items)

--- a/kensu/utils/kensu.py
+++ b/kensu/utils/kensu.py
@@ -331,9 +331,14 @@ class Kensu(object):
                         try:
                             stats = self.extractors.extract_stats(stats_df)
                         except:
+                            from kensu.requests.models import ksu_str
                             # FIXME weird... should be fine to delete (and try,except too)
                             if isinstance(stats_df, pd.DataFrame) or isinstance(stats_df, DataFrame) or isinstance(stats_df,Series) or isinstance(stats_df,pd.Series) :
                                 stats = self.extractors.extract_stats(stats_df)
+                            elif isinstance(stats_df, ksu_str):
+                                stats = None
+                            elif isinstance(stats_df, dict):
+                                stats = stats_df
                             else:
                                 #TODO Support ndarray
                                 stats = None

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -7,4 +7,5 @@ pandas>=1.2.4
 numpy>=1.19.5
 scikit-learn>=0.24.2
 GitPython
-gluonts
+gluonts==0.6.5
+boto3

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from setuptools import setup, find_packages
 NAME = "kensu"
 
 
-VERSION = "1.4.3.1"
+VERSION = "1.4.4"
 
 
 # To install the library, run the following

--- a/tests/unit/test_aws.py
+++ b/tests/unit/test_aws.py
@@ -1,0 +1,26 @@
+if __name__ == '__main__':
+    import os
+    from kensu import requests
+    from kensu.utils.kensu_provider import KensuProvider
+    import kensu.boto3 as boto3
+
+    ## kensu setup
+    offline = True
+    api_url = os.environ.get('KSU_API_URL') or ''
+    auth_token = os.environ.get('KSU_API_TOKEN') or ''
+    kensu = KensuProvider().initKensu(init_context=True,
+                                      api_url=api_url,
+                                      auth_token=auth_token,
+                                      report_to_file=offline,
+                                      project_names=['aws s3'],
+                                      offline_file_name='kensu-offline-to-aws-s3-test.jsonl',
+                                      mapping=True, report_in_mem=False)
+    #### end of kensu setup
+
+    response = requests.get(url="http://api.open-notify.org/astros.json")
+
+    S3 = boto3.resource('s3', region_name='eu-west-1')
+
+    s3_obj_name = 'test-file-v'
+    s3_obj = S3.Object(os.environ.get('S3_BUCKET_NAME'), s3_obj_name)
+    s3_obj.put(Body = response.text)

--- a/tests/unit/test_pandas.py
+++ b/tests/unit/test_pandas.py
@@ -15,8 +15,8 @@ logging.basicConfig(stream=sys.stdout, level=logging.INFO, format=log_format)
 
 
 class TestPandas(unittest.TestCase):
-    token = "eyJhbGciOiJIUzI1NiJ9.eyIkaW50X3Blcm1zIjpbXSwic3ViIjoib3JnLnBhYzRqLmNvcmUucHJvZmlsZS5Db21tb25Qcm9maWxlI3NhbW15IiwidG9rZW5faWQiOiI4NmYxMWU0Ni02NDk1LTRkNWItODhjZS01ODk1NTAxNDM0NzUiLCJhcHBncm91cF9pZCI6IjUyZTVkNDNjLTM0ZGYtNGRkZi1hM2Y3LTIwODU2Y2MzOWY2ZCIsIiRpbnRfcm9sZXMiOlsiYXBwIl0sImV4cCI6MTg4ODE0MTk2NiwiaWF0IjoxNTcyNzgxOTY2fQ.4CdaN9a80xc1ry6aT52MFxc33vb0nJVXX5TdGzdoJ7E"
-    kensu = KensuProvider().initKensu(api_url="https://api.sandbox.kensu.io", auth_token=token, init_context=True)
+    token = ""
+    kensu = KensuProvider().initKensu(api_url="", auth_token=token, init_context=True)
 
     # FIXME... dunno ... that sounds rather nasty
     # def _constructor(self):


### PR DESCRIPTION
some further cleanup and improvements for later on, e.g.:
-  [ ] we currently track on `provide-client-params.s3.PutObject` which might not guarantee the object was sent to s3 yet
-  [ ] track s3 writes when input DS is not requests.reponse.body.text 
-  [ ] track s3 writes when input is not recognized/not known