### PR TITLE
AWS layer auto deploying and fix repeated initKensu

### DIFF
--- a/.github/workflows/aws-upload-layer-on-release.yml
+++ b/.github/workflows/aws-upload-layer-on-release.yml
@@ -50,7 +50,7 @@ jobs:
           # e.g. ${{ format('s3://{0}', secrets.S3_BUCKET_NAME) }}
           release_bucket_uri: ${{ format('{0}/', secrets.S3_LAYER_UPLOAD_DIR) }}
           # for layers of PRs we could also use github.ref_head
-          release_id: ${{ format('{}/kensu-py-{0}-dev.zip', secrets.S3_LAYER_UPLOAD_DIR, github.sha )}}
+          release_id: ${{ format('{0}/kensu-py-{1}-dev.zip', secrets.S3_LAYER_UPLOAD_DIR, github.sha )}}
           release_layer: 'kensu-py--dev'
         run: |
           mkdir python

--- a/.github/workflows/aws-upload-layer-on-release.yml
+++ b/.github/workflows/aws-upload-layer-on-release.yml
@@ -48,7 +48,7 @@ jobs:
           release_bucket: ${{ secrets.S3_BUCKET_NAME }}
           # '<the uri for your S3 bucket - like s3://my_bucket_name>'
           # e.g. ${{ format('s3://{0}', secrets.S3_BUCKET_NAME) }}
-          release_bucket_uri: ${{ secrets.S3_LAYER_UPLOAD_DIR }}
+          release_bucket_uri: ${{ format('{0}/', secrets.S3_LAYER_UPLOAD_DIR) }}
           # for layers of PRs we could also use github.ref_head
           release_id: ${{ format('kensu-py-{0}-dev.zip', github.sha )}}
           release_layer: 'kensu-py--dev'

--- a/.github/workflows/aws-upload-layer-on-release.yml
+++ b/.github/workflows/aws-upload-layer-on-release.yml
@@ -47,7 +47,8 @@ jobs:
         env:
           release_bucket: ${{ secrets.S3_BUCKET_NAME }}
           # '<the uri for your S3 bucket - like s3://my_bucket_name>'
-          release_bucket_uri: ${{ format('s3://{0}', secrets.S3_BUCKET_NAME) }}
+          # e.g. ${{ format('s3://{0}', secrets.S3_BUCKET_NAME) }}
+          release_bucket_uri: ${{ secrets.S3_LAYER_UPLOAD_DIR }}
           # for layers of PRs we could also use github.ref_head
           release_id: ${{ format('kensu-py-{0}-dev.zip', github.sha )}}
           release_layer: 'kensu-py--dev'

--- a/.github/workflows/aws-upload-layer-on-release.yml
+++ b/.github/workflows/aws-upload-layer-on-release.yml
@@ -51,7 +51,7 @@ jobs:
           release_bucket_uri: ${{ format('s3://{0}/{1}/', secrets.S3_BUCKET_NAME, secrets.S3_LAYER_UPLOAD_DIR) }}
           # for layers of PRs we could also use github.ref_head
           release_id: ${{ format('kensu-py-{0}-dev.zip', github.sha ) }}
-          release_file_key: ${{ format('{0}/{1}', secrets.S3_LAYER_UPLOAD_DIR, $release_id) }}
+          release_file_key: ${{ format('{0}/{1}', secrets.S3_LAYER_UPLOAD_DIR, format('kensu-py-{0}-dev.zip', github.sha )) }}
           release_layer: 'kensu-py--dev'
         run: |
           mkdir python

--- a/.github/workflows/aws-upload-layer-on-release.yml
+++ b/.github/workflows/aws-upload-layer-on-release.yml
@@ -48,9 +48,10 @@ jobs:
           release_bucket: ${{ secrets.S3_BUCKET_NAME }}
           # '<the uri for your S3 bucket - like s3://my_bucket_name>'
           # e.g. ${{ format('s3://{0}', secrets.S3_BUCKET_NAME) }}
-          release_bucket_uri: ${{ format('{0}/', secrets.S3_LAYER_UPLOAD_DIR) }}
+          release_bucket_uri: ${{ format('s3://{0}/{1}/', secrets.S3_BUCKET_NAME, secrets.S3_LAYER_UPLOAD_DIR) }}
           # for layers of PRs we could also use github.ref_head
-          release_id: ${{ format('{0}/kensu-py-{1}-dev.zip', secrets.S3_LAYER_UPLOAD_DIR, github.sha )}}
+          release_id: ${{ format('kensu-py-{0}-dev.zip', github.sha ) }}
+          release_file_key: ${{ format('{0}/{1}', secrets.S3_LAYER_UPLOAD_DIR, $release_id) }}
           release_layer: 'kensu-py--dev'
         run: |
           mkdir python
@@ -63,4 +64,4 @@ jobs:
           # copy the file to S3 and install it in lambda layers
           aws s3 cp $release_id $release_bucket_uri
           # fixme: update compatible runtimes
-          aws lambda publish-layer-version --layer-name $release_layer  --content S3Bucket=$release_bucket,S3Key=$release_id --compatible-runtimes python3.6 python3.7 python3.8 python3.9
+          aws lambda publish-layer-version --layer-name $release_layer  --content S3Bucket=$release_bucket,S3Key=$release_file_key --compatible-runtimes python3.6 python3.7 python3.8 python3.9

--- a/.github/workflows/aws-upload-layer-on-release.yml
+++ b/.github/workflows/aws-upload-layer-on-release.yml
@@ -50,7 +50,7 @@ jobs:
           # e.g. ${{ format('s3://{0}', secrets.S3_BUCKET_NAME) }}
           release_bucket_uri: ${{ format('{0}/', secrets.S3_LAYER_UPLOAD_DIR) }}
           # for layers of PRs we could also use github.ref_head
-          release_id: ${{ format('kensu-py-{0}-dev.zip', github.sha )}}
+          release_id: ${{ format('{}/kensu-py-{0}-dev.zip', secrets.S3_LAYER_UPLOAD_DIR, github.sha )}}
           release_layer: 'kensu-py--dev'
         run: |
           mkdir python

--- a/.github/workflows/awsLayer.yml
+++ b/.github/workflows/awsLayer.yml
@@ -48,8 +48,9 @@ jobs:
           release_bucket: ${{ secrets.S3_BUCKET_NAME }}
           # '<the uri for your S3 bucket - like s3://my_bucket_name>'
           release_bucket_uri: ${{ format('s3://{0}', secrets.S3_BUCKET_NAME) }}
-          release_id: ${{ format('kensu-py-{0}-dev.zip', github.head_ref )}}
-          release_layer: ${{ format('kensu-py-{0}-dev', github.head_ref )}}
+          # for layers of PRs we could also use github.ref_head
+          release_id: ${{ format('kensu-py-{0}-dev.zip', github.sha )}}
+          release_layer: 'kensu-py--dev'
         run: |
           mkdir python
           pip install -r requirements.txt -t python

--- a/.github/workflows/awsLayer.yml
+++ b/.github/workflows/awsLayer.yml
@@ -35,16 +35,19 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
+          # if you have/need it
+          aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
 
-      - name: Setup Python 3.8
+      - name: Setup Python 3.x
         uses: actions/setup-python@v1
         with:
           python-version: '3.x'
 
       - name: Zip it all up and upload to S3
         env:
-          release_bucket: '<your AWS S3 bucket name goes here>'
-          release_bucket_uri: '<the uri for your S3 bucket - like s3://my_bucket_name>'
+          release_bucket: ${{ secrets.S3_BUCKET_NAME }}
+          # '<the uri for your S3 bucket - like s3://my_bucket_name>'
+          release_bucket_uri: ${{ format('s3://{0}', secrets.S3_BUCKET_NAME) }}
           release_id: ${{ format('kensu-py-{0}-dev.zip', github.head_ref )}}
           release_layer: ${{ format('kensu-py-{0}-dev', github.head_ref )}}
         run: |

--- a/kensu/utils/kensu_provider.py
+++ b/kensu/utils/kensu_provider.py
@@ -22,7 +22,7 @@ class KensuProvider(object):
         if ksu_provided_inst is not None and allow_reinit:
             logging.warning("KensuProvider.initKensu called more than once - reinitializing as requested by allow_reinit=True")
             KensuProvider().setKensu(None)
-        if ksu_provided_inst is None:
+        if ksu_provided_inst is None or allow_reinit:
             from kensu.utils.kensu import Kensu
             pandas_support = kwargs["pandas_support"] if "pandas_support" in kwargs else True
             sklearn_support = kwargs["sklearn_support"] if "sklearn_support" in kwargs else True

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,6 @@ urllib3 >= 1.15.1
 datetime
 requests
 configparser
+# these can be made optional
+pandas>=1.2.4
+numpy>=1.19.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ urllib3 >= 1.15.1
 datetime
 requests
 configparser
-# these can be made optional
-pandas>=1.2.4
-numpy>=1.19.5
+# these can be made optional later on
+#pandas>=1.2.4
+#numpy>=1.19.5


### PR DESCRIPTION
layer autodeploying already tested on a forked repo - works great.

will need to set the secrets to dedicated secret key (and better unique new bucket for extra security) in the repo secrets. until then the workflow can be disabled.
<img width="308" alt="Screenshot 2021-09-08 at 17 28 45" src="https://user-images.githubusercontent.com/213426/132528518-a7d610d5-a7bf-4532-b438-1649e1736982.png">
