### PR TITLE
Fix dependency install

### DIFF
--- a/.github/workflows/aws-upload-layer-on-release.yml
+++ b/.github/workflows/aws-upload-layer-on-release.yml
@@ -67,6 +67,7 @@ jobs:
           release_layer: 'kensu-py--dev'
         run: |
           mkdir python
+          python -m pip install --upgrade pip
           pip install -e ".[no-extra-deps]"
           pip install .
           echo building release $release_id

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
         for package in setuptools.PEP420PackageFinder.find()
         if package.startswith("kensu")
     ],
-    required=[
+    install_requires=[
         # build
         "setuptools >= 21.0.0"
         , "twine >= 3.4.1"


### PR DESCRIPTION
no non-extra dependencies where installed since merging #50  (so auto builds were failing - generating empty builds for AWS layer for example https://github.com/kensuio-oss/kensu-py/actions ), my quick guess is that `required=` was a wrongly named keyword.

seem to fix the thingy locally, let's test on AWS layer build.