### PR TITLE
Fix aws build script

### DIFF
--- a/.github/workflows/aws-upload-layer-on-release.yml
+++ b/.github/workflows/aws-upload-layer-on-release.yml
@@ -68,8 +68,8 @@ jobs:
         run: |
           mkdir python
           python -m pip install --upgrade pip
-          pip install -e ".[no-extra-deps]"
-          pip install .
+          pip install -e ".[no-extra-deps]" -t python
+          pip install . -t python
           echo building release $release_id
           # zip it up
           zip --quiet -r $release_id python


### PR DESCRIPTION
was broken in https://github.com/kensuio-oss/kensu-py/pull/50

see original build script had `-t python` ( https://github.com/kensuio-oss/kensu-py/pull/50/files#diff-aa6bbd06eae4f6861c58aa5a0148d070bd9ef6142b06225b20de3725f59ab570L70-L71 ) to put installed packages into the right folder to be gathered by `zip`command below 
