### PR TITLE
sql.util.url now sql_util_url and also reachable through initKensu kwargs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Extra libraries support (TODO: to be extracted in different modules)
 - sklearn_support: Boolean
 - bigquery_support: Boolean
 - tensorflow_support: Boolean
-- sql.util.url: URL to an external server capable of handling SQL parsing into lineage
+- sql_util_url: URL to an external server capable of handling SQL parsing into lineage
 
 #### Reporters
 

--- a/conf.ini
+++ b/conf.ini
@@ -16,7 +16,7 @@
 ;sklearn_support
 ;bigquery_support
 ;tensorflow_support
-;sql.util.url
+;sql_util_url
 
 [kensu.reporter]
 ; Name (class but conventional for now) of the reporter

--- a/kensu/google/cloud/bigquery/job/remote_parser.py
+++ b/kensu/google/cloud/bigquery/job/remote_parser.py
@@ -32,7 +32,7 @@ class BqRemoteParser:
     def parse(kensu, client: bq.Client, query: str, db_metadata, table_id_to_bqtable) -> GenericComputedInMemDs:
         ## POST REQUEST to /lineage-and-stats-criterions
         req = {"sql": query, "metadata": db_metadata}
-        url = kensu.conf.get("sql.util.url")
+        url = kensu.sql_util_url
         logger.debug("sending request to SQL parsing service url={} request={}".format(url, str(req)))
         import requests
         def convert(fieldtype):

--- a/kensu/utils/kensu.py
+++ b/kensu/utils/kensu.py
@@ -131,6 +131,7 @@ class Kensu(object):
         logical_naming = kwargs_or_conf_or_default("logical_naming", None)
         mapping = kwargs_or_conf_or_default("mapping", None)
         report_in_mem = kwargs_or_conf_or_default("report_in_mem", False)
+        sql_util_url = kwargs_or_conf_or_default("sql_util_url", None)
 
         if "get_code_version" in kwargs and kwargs["get_code_version"] is not None:
             get_code_version = kwargs["get_code_version"]
@@ -175,6 +176,7 @@ class Kensu(object):
         self.report_in_mem = report_in_mem
         self.compute_stats = compute_stats
         self.offline_file_name = offline_file_name
+        self.sql_util_url = sql_util_url
 
         self.set_default_physical_location(Kensu.UNKNOWN_PHYSICAL_LOCATION)
         # can be updated using set_default_physical_location

--- a/kensu/utils/kensu_provider.py
+++ b/kensu/utils/kensu_provider.py
@@ -38,6 +38,7 @@ class KensuProvider(object):
             report_in_mem = kwargs["report_in_mem"] if "report_in_mem" in kwargs else False
             get_code_version = kwargs["get_code_version"] if "get_code_version" in kwargs else None
             stats = kwargs["compute_stats"] if "compute_stats" in kwargs else True
+            sql_util_url = kwargs["sql_util_url"] if "sql_util_url" in kwargs else None
 
             _kensu = Kensu(api_url=api_url, auth_token=auth_token, process_name=process_name, user_name=user_name,
                       code_location=code_location, init_context=init_context, do_report=do_report, pandas_support = pandas_support,
@@ -45,7 +46,7 @@ class KensuProvider(object):
                       project_names=project_names,environment=environment,timestamp=timestamp,logical_naming=logical_naming,mapping=mapping, report_in_mem = report_in_mem,
                       report_to_file=report_to_file, offline_file_name=offline_file_name, reporter=reporter,
                       get_code_version=get_explicit_code_version_fn or get_code_version or get_code_version_fn,
-                      compute_stats=stats, bigquery_headers = bigquery_headers)
+                      compute_stats=stats, bigquery_headers = bigquery_headers, sql_util_url= sql_util_url)
 
             KensuProvider().setKensu(_kensu)
             return _kensu

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from setuptools import setup, find_packages
 NAME = "kensu"
 
 
-VERSION = "1.6.5"
+VERSION = "1.6.6"
 
 
 # To install the library, run the following

--- a/tests/unit/conf.ini
+++ b/tests/unit/conf.ini
@@ -1,5 +1,5 @@
 [kensu]
-sql.util.url=http://127.0.0.1:5000
+sql_util_url=http://127.0.0.1:5000
 ;api_url
 ;api_token
 ;project_names
@@ -17,6 +17,6 @@ sql.util.url=http://127.0.0.1:5000
 ;sklearn_support
 ;bigquery_support
 ;tensorflow_support
-;sql.util.url
+;sql_util_url
 
 [kensu.reporter]


### PR DESCRIPTION
The dots in the conf item sql.util.url prevented it to be integrated like the other underscored conf items