### PR TITLE
Improve BigQuery collector

### DIFF
--- a/kensu/google/cloud/bigquery/client.py
+++ b/kensu/google/cloud/bigquery/client.py
@@ -68,7 +68,8 @@ class Client(client.Client):
                     db_metadata, table_id_to_bqtable, table_infos = BqOfflineParser.get_referenced_tables_metadata(
                         kensu=kensu,
                         client=client,
-                        query=query.replace("\n", " ")
+                        job=j, # FIXME: here job might be not finished yet, and thus, not have some of the stats
+                        query=BqOfflineParser.normalize_table_refs(query.replace("\n", " ")) # FIXME: or replace in query sent to online parser too?
                     )
 
                     try:
@@ -85,6 +86,7 @@ class Client(client.Client):
                     db_metadata_out, table_id_to_bqtable_out, table_infos_out = BqOfflineParser.get_referenced_tables_metadata(
                         kensu=kensu,
                         client=client,
+                        job=j,
                         table=dest)
 
                     table_infos_out[0][1]._report()
@@ -154,6 +156,7 @@ class Client(client.Client):
         dest_metadata, table_id_to_bqtable, table_infos = BqOfflineParser.get_referenced_tables_metadata(
             kensu=kensu,
             client=gclient,
+            job=None,
             table=destination)
         ds = table_infos[0][1]._report()
         sc = table_infos[0][2]._report()

--- a/kensu/google/cloud/bigquery/job/offline_parser.py
+++ b/kensu/google/cloud/bigquery/job/offline_parser.py
@@ -100,7 +100,7 @@ class BqOfflineParser:
             table_id: Union[Table, TableReference, str],
     ):
         table = client.get_table(table_id)
-        ds, sc = BqKensuHelpers.table_to_kensu(table)  # FIXME?
+        ds, sc = BqKensuHelpers.table_to_kensu(table)
         return table, ds, sc
 
     @staticmethod

--- a/kensu/google/cloud/bigquery/job/offline_parser.py
+++ b/kensu/google/cloud/bigquery/job/offline_parser.py
@@ -4,6 +4,7 @@
 # Copyright 2021 Kensu Inc
 #
 import logging
+import re
 from typing import Union
 
 from google.cloud.bigquery import Table, TableReference
@@ -24,12 +25,15 @@ class BqOfflineParser:
 
     @staticmethod
     def normalize_table_refs(q):
-        # FIXME: this might be error prone!?
+        # FIXME: this might be still quite error prone in non-standard use-cases...
         """
         >>> normalize_table_refs('SELECT * FROM `a1`.`b2`.`c3`')
         'SELECT * FROM `a1.b2.c3`'
         """
-        # FIXME: use regex
+        matches = re.findall(r'`([a-zA-Z0-9-_]+)`.`([a-zA-Z0-9-_]+)`.`([a-zA-Z0-9-_]+)`', q)
+        for (s1, s2, s3) in matches:
+            q = q.replace(f'`{s1}`.`{s2}`.`{s3}`', f'`{s1}.{s2}.{s3}`')
+
         return q
 
     @staticmethod

--- a/kensu/google/cloud/bigquery/job/offline_parser.py
+++ b/kensu/google/cloud/bigquery/job/offline_parser.py
@@ -42,7 +42,8 @@ class BqOfflineParser:
         table_infos = []
         if job:
             # Referenced tables for the job. Queries that reference more than 50 tables will not have a complete list.
-            referenced_tables = job.referenced_tables # type: list[TableReference]
+            # FIXME: separate referenced from ddl target
+            referenced_tables = job.referenced_tables + [j for j in [job.ddl_target_table] if j] # type: list[TableReference]
             # [TableReference(DatasetReference('project', 'db'), 'table')]
             table_infos = list([BqOfflineParser.table_ref_to_kensu(client, table_id=t)
                             for t in referenced_tables])

--- a/kensu/google/cloud/bigquery/job/offline_parser.py
+++ b/kensu/google/cloud/bigquery/job/offline_parser.py
@@ -15,7 +15,6 @@ from kensu.utils.dsl.extractors.external_lineage_dtos import KensuDatasourceAndS
 from kensu.utils.helpers import extract_ksu_ds_schema
 from kensu.utils.kensu import Kensu
 import google.cloud.bigquery as bq
-#import google.cloud.bigquery
 import sqlparse
 
 logger = logging.getLogger(__name__)

--- a/kensu/google/cloud/bigquery/job/offline_parser.py
+++ b/kensu/google/cloud/bigquery/job/offline_parser.py
@@ -4,8 +4,9 @@
 # Copyright 2021 Kensu Inc
 #
 import logging
+from typing import Union
 
-from google.cloud.bigquery import Table
+from google.cloud.bigquery import Table, TableReference
 
 from kensu.google.cloud.bigquery.job.bq_helpers import BqKensuHelpers
 from kensu.utils.dsl.extractors.external_lineage_dtos import KensuDatasourceAndSchema, GenericComputedInMemDs, \
@@ -13,6 +14,7 @@ from kensu.utils.dsl.extractors.external_lineage_dtos import KensuDatasourceAndS
 from kensu.utils.helpers import extract_ksu_ds_schema
 from kensu.utils.kensu import Kensu
 import google.cloud.bigquery as bq
+#import google.cloud.bigquery
 import sqlparse
 
 logger = logging.getLogger(__name__)
@@ -20,24 +22,59 @@ logger = logging.getLogger(__name__)
 
 class BqOfflineParser:
 
-    # FIXME: or should we better simply fetch schema ALL visible tables and databases !!!!???
+    @staticmethod
+    def normalize_table_refs(q):
+        # FIXME: this might be error prone!?
+        """
+        >>> normalize_table_refs('SELECT * FROM `a1`.`b2`.`c3`')
+        'SELECT * FROM `a1.b2.c3`'
+        """
+        # FIXME: use regex
+        return q
+
     @staticmethod
     def get_referenced_tables_metadata(
             kensu: Kensu,
             client: bq.Client,
+            job,  # type: google.cloud.bigquery.job.QueryJob
             query: str = None,
             table: Table = None):
+        table_infos = []
+        if job:
+            # Referenced tables for the job. Queries that reference more than 50 tables will not have a complete list.
+            referenced_tables = job.referenced_tables # type: list[TableReference]
+            # [TableReference(DatasetReference('project', 'db'), 'table')]
+            table_infos = list([BqOfflineParser.table_ref_to_kensu(client, table_id=t)
+                            for t in referenced_tables])
+        is_bigquery_api_limit_reached = len(table_infos) > 49
+        if not table_infos or is_bigquery_api_limit_reached:
+            fallback_tables = list(BqOfflineParser.fallback_referenced_tables_from_sql(kensu=kensu,
+                                                                              client=client,
+                                                                              query=query,
+                                                                              table=query))
+            table_infos = list(set(table_infos + fallback_tables))
+        return BqOfflineParser.to_sql_util_metadata(table_infos)
+
+
+    # FIXME: or should we better simply fetch schema for ALL visible tables and databases !!!!???
+    @staticmethod
+    def fallback_referenced_tables_from_sql(
+            kensu: Kensu,
+            client: bq.Client,
+            query: str = None,
+            table: Table = None):
+        # FIXME: return table/tableRef here?!
         if query:
             table_infos = BqOfflineParser.get_table_info_from_sql(client, query)
         elif table:
-            tb = client.get_table(table)
-            ds,sc = BqKensuHelpers.table_to_kensu(tb)
-            table_infos = [(tb,ds,sc)]
+            table_infos = [BqOfflineParser.table_ref_to_kensu(client, table_id=table)]
+        else:
+            table_infos = []
+        return table_infos
 
-        # for table, ds, sc in table_infos:
-        #     # FIXME: this possibly don't fit here well...
-        #     kensu.real_schema_df[sc.to_guid()] = table
 
+    @staticmethod
+    def to_sql_util_metadata(table_infos):
         table_id_to_bqtable = {}
         metadata = {"tables": []}
         for table, ds, sc in table_infos:
@@ -52,6 +89,16 @@ class BqOfflineParser:
             metadata["tables"].append(table_md)
         return metadata,  table_id_to_bqtable, table_infos
 
+
+    @staticmethod
+    def table_ref_to_kensu(
+            client: bq.Client,
+            table_id: Union[Table, TableReference, str],
+    ):
+        table = client.get_table(table_id)
+        ds, sc = BqKensuHelpers.table_to_kensu(table)  # FIXME?
+        return table, ds, sc
+
     @staticmethod
     def get_table_info_for_id(client: bq.Client, id: sqlparse.sql.Identifier or sqlparse.sql.Token):
         try:
@@ -59,9 +106,7 @@ class BqOfflineParser:
                 name = (id.get_real_name()).strip('`')
             elif isinstance(id,sqlparse.sql.Token):
                 name = id.value.strip('`')
-            table = client.get_table(name)
-            ds, sc = BqKensuHelpers.table_to_kensu(table)  # FIXME?
-            return table, ds, sc
+            return BqOfflineParser.table_ref_to_kensu(client, table_id=name)
         except Exception as e:
             logger.debug("get_table_info_for_id failed for table={}, maybe not BQ table: {}".format(id, str(e)))
             # FIXME this is because the current find_sql_identifiers also returns the column names...

--- a/kensu/google/cloud/bigquery/job/query.py
+++ b/kensu/google/cloud/bigquery/job/query.py
@@ -64,7 +64,8 @@ class QueryJob(bqj.QueryJob):
             ddl_target_table = job.ddl_target_table
             dest = job.destination or ddl_target_table
             is_ddl_write = bool(ddl_target_table)
-            print(f'in QueryJob.result(): dest={dest}')
+            logger.debug(f'in QueryJob.result(): dest={dest}')
+            logger.debug(f'in QueryJob.result(): referenced={job.referenced_tables}')
             if isinstance(dest, bq.TableReference):
                 dest = client.get_table(dest)
 

--- a/tests/unit/mocked_bigquery/__init__.py
+++ b/tests/unit/mocked_bigquery/__init__.py
@@ -81,7 +81,7 @@ def mock(mocker):
                 spec=google.cloud.bigquery.job.query.QueryJob,
                 query=sample_sql,
                 referenced_tables=list(table_id_to_bqtable.keys()),
-                ddl_target_table=None
+                ddl_target_table=None,
                 destination=res_table,
                 result=lambda: job_result
             ),

--- a/tests/unit/mocked_bigquery/__init__.py
+++ b/tests/unit/mocked_bigquery/__init__.py
@@ -10,8 +10,8 @@ from kensu.google.cloud import bigquery as kensu_bigquery
 from kensu.google.cloud.bigquery.job.offline_parser import BqOfflineParser
 
 sample_sql = f"""SELECT DATE_KEY, "ARG" AS COUNTRY_KEY, s.STORE_KEY, CHAIN_TYPE_DESC, CARD_FLAG, sum(TOTAL) AS CA 
-            FROM `psyched-freedom-306508.cf.ARG-stores` AS s 
-            INNER JOIN `psyched-freedom-306508.cf.ARG-tickets` AS t 
+            FROM `psyched-freedom-306508`.`cf`.ARG-stores` AS s
+            INNER JOIN `psyched-freedom-306508.cf.ARG-tickets` AS t
             ON s.STORE_KEY = t.STORE_KEY
             WHERE DATE_KEY = "2021-05-23" 
             GROUP BY DATE_KEY, s.STORE_KEY, CHAIN_TYPE_DESC, CARD_FLAG"""

--- a/tests/unit/mocked_bigquery/__init__.py
+++ b/tests/unit/mocked_bigquery/__init__.py
@@ -80,7 +80,9 @@ def mock(mocker):
                 # define job.result here with type Iterator?
                 spec=google.cloud.bigquery.job.query.QueryJob,
                 query=sample_sql,
-                result=lambda: job_result
+                result=lambda: job_result,
+                referenced_tables=list(table_id_to_bqtable.keys()),
+                ddl_target_table=None
             ),
         },
         attr_values={


### PR DESCRIPTION
- **start using the queryJob.`{referenced_tables|ddl_target_table}` methods** (from bigquery itself) as main method to resolve what are the input and output BigQuery tables, which out-of-the box return enough of reliable query "introspection" for the basic use-cases (instead of clunky SQL parser).
  - however, this has limitation of max 50 input tables, so we use the old parser as a fallback in that case
- **added normalization of table names**, so now we support both of:
```
`a1`.`b2`.`c3` # new
`a1.b2.c3` # existed earlier
``` 