### PR TITLE
fix bigquery and other stats

### DIFF
--- a/kensu/google/cloud/bigquery/job/remote_parser.py
+++ b/kensu/google/cloud/bigquery/job/remote_parser.py
@@ -90,7 +90,7 @@ class BqRemoteParser:
                         input_filters=stats_filters)
                 except Exception as e:
                     stats_values = None
-                    logger.info(f"Unable to compute the stats: {e}")
+                    logger.warning(f"Unable to compute the stats: {e}")
 
             logger.debug(
                 f'table_id {table_id} (table.ref={bg_table_ref}, ds_path: {ds_path}) got input_filters: {stats_filters} & stat_aggs:{str(stats_aggs)}')

--- a/kensu/google/cloud/bigquery/job/remote_parser.py
+++ b/kensu/google/cloud/bigquery/job/remote_parser.py
@@ -90,7 +90,7 @@ class BqRemoteParser:
                         input_filters=stats_filters)
                 except Exception as e:
                     stats_values = None
-                    logger.debug(f"Unable to compute the stats: {e}")
+                    logger.info(f"Unable to compute the stats: {e}")
 
             logger.debug(
                 f'table_id {table_id} (table.ref={bg_table_ref}, ds_path: {ds_path}) got input_filters: {stats_filters} & stat_aggs:{str(stats_aggs)}')

--- a/kensu/pyspark/spark_connector.py
+++ b/kensu/pyspark/spark_connector.py
@@ -337,7 +337,7 @@ def scala_ds_and_schema_to_py(dam, ds, schema):
     def f_get_stats():
         # ******************************************************************************************
         # WARNING : Do not return anything else than None, because f_publish_stats is preferred giving the responsibility
-        # to Spark to send the data stats only when it's available (Future computation is completed)
+        # to Spark to send the data stats only when it's available (when computation inside scala Future is completed)
         # ******************************************************************************************
         return None
     return KensuDatasourceAndSchema(ksu_ds=py_ds, ksu_schema=py_schema, f_get_stats=f_get_stats, f_publish_stats = f_publish_stats)

--- a/kensu/utils/dsl/extractors/external_lineage_dtos.py
+++ b/kensu/utils/dsl/extractors/external_lineage_dtos.py
@@ -8,11 +8,11 @@ class KensuDatasourceAndSchema:
                  ksu_ds,
                  ksu_schema,
                  f_get_stats=lambda: None,
-                 f_publish_stats = lambda lineage_run_id : {}):
+                 f_publish_stats=lambda lineage_run_id: {}):
         """
         :param kensu.client.DataSource ksu_ds: Datasource info which was extracted from external system
         :param kensu.client.Schema ksu_schema: Schema info for the datasource
-        :param () -> typing.Dict[string, float] f_get_stats: [Optional] a function to retrieve DataStats for this DataSource
+        :param () -> typing.Union[typing.Dict[string, float], None] f_get_stats: [Optional] a function to retrieve DataStats for this DataSource
         :param (str) -> () f_publish_stats : [Optional] a function publishing the statistics given a lineage run guid
         """
 

--- a/kensu/utils/kensu.py
+++ b/kensu/utils/kensu.py
@@ -459,7 +459,7 @@ class Kensu(object):
                             # as an example - stats publishing directly from Apache Spark JVM
                             # for pyspark's python-JVM interop jobs (where data moves between Spark & Python)
                             stats_df.f_publish_stats(lineage_run.to_guid())
-                        elif stats is None:
+                        elif stats is not None:
                             self.schema_stats[schema_guid] = stats
                             if lineage_run.to_guid() not in self.stats_to_send:
                                 self.stats_to_send[lineage_run.to_guid()] = {}

--- a/kensu/utils/kensu.py
+++ b/kensu/utils/kensu.py
@@ -339,7 +339,7 @@ class Kensu(object):
         try:
             stats = self.extractors.extract_stats(stats_df)
         except Exception as e:
-            logging.info(f'stats extraction from {type(stats_df)} failed', e)
+            logging.warning(f'stats extraction from {type(stats_df)} failed', e)
             if isinstance(stats_df, dict):
                 # FIXME: this is weird logic here... we'd post the actual data instead of stats!
                 stats = stats_df

--- a/kensu/utils/kensu.py
+++ b/kensu/utils/kensu.py
@@ -439,7 +439,8 @@ class Kensu(object):
                     def create_stats(schema_guid):
                         stats_df = self.real_schema_df[schema_guid]
 
-                        if isinstance(stats_df, KensuDatasourceAndSchema):
+                        # FIXME: ideally need to prevent f_get_stats called multiple times
+                        if isinstance(stats_df, KensuDatasourceAndSchema) and not stats_df.f_get_stats:
                             stats_df.f_publish_stats(lineage_run.to_guid())
 
                         else:

--- a/kensu/utils/kensu.py
+++ b/kensu/utils/kensu.py
@@ -452,35 +452,34 @@ class Kensu(object):
 
                     def create_stats(schema_guid):
                         stats_df = self.real_schema_df[schema_guid]
-                        if True:
-                            stats = self.extract_stats(stats_df)
-                            if stats is None and isinstance(stats_df, KensuDatasourceAndSchema):
-                                # in this special case, the stats are reported not by kensu-py,
-                                # but by some external library called from .f_publish_stats callback
-                                # as an example - stats publishing directly from Apache Spark JVM
-                                # for pyspark's python-JVM interop jobs (where data moves between Spark & Python)
-                                stats_df.f_publish_stats(lineage_run.to_guid())
-                            elif stats is None:
-                                self.schema_stats[schema_guid] = stats
-                                if lineage_run.to_guid() not in self.stats_to_send:
-                                    self.stats_to_send[lineage_run.to_guid()] = {}
-                                self.stats_to_send[lineage_run.to_guid()][schema_guid] = stats
-                                if schema_guid == to_guid:
-                                    if 'nrows' in stats and self.compute_delta:
-                                        # fixme: extract a helper
-                                        output_nrows = stats['nrows']
-                                        #TODO Corner case: if from_pk = to_pk
-                                        for input_schema_guid in from_pks:
-                                            input_stats = self.schema_stats.get(input_schema_guid)
-                                            input_nrows = input_stats and input_stats.get('nrows')
-                                            if input_nrows:
-                                                delta_nrows = input_nrows - output_nrows
-                                                input_name = self.logical_name_by_guid.get(input_schema_guid, self.schema_name_by_guid.get(input_schema_guid))
-                                                clean_input_name = self.name_for_stats(input_name)
-                                                stats['delta.nrows_' + clean_input_name + '.abs']=delta_nrows
-                                                stats['delta.nrows_' + clean_input_name + '.decrease in %'] = round(100*delta_nrows/input_nrows,2)
-                                        self.schema_stats[schema_guid] = stats
-                                        self.stats_to_send[lineage_run.to_guid()][schema_guid] = stats
+                        stats = self.extract_stats(stats_df)
+                        if stats is None and isinstance(stats_df, KensuDatasourceAndSchema):
+                            # in this special case, the stats are reported not by kensu-py,
+                            # but by some external library called from .f_publish_stats callback
+                            # as an example - stats publishing directly from Apache Spark JVM
+                            # for pyspark's python-JVM interop jobs (where data moves between Spark & Python)
+                            stats_df.f_publish_stats(lineage_run.to_guid())
+                        elif stats is None:
+                            self.schema_stats[schema_guid] = stats
+                            if lineage_run.to_guid() not in self.stats_to_send:
+                                self.stats_to_send[lineage_run.to_guid()] = {}
+                            self.stats_to_send[lineage_run.to_guid()][schema_guid] = stats
+                            if schema_guid == to_guid:
+                                if 'nrows' in stats and self.compute_delta:
+                                    # fixme: extract a helper
+                                    output_nrows = stats['nrows']
+                                    #TODO Corner case: if from_pk = to_pk
+                                    for input_schema_guid in from_pks:
+                                        input_stats = self.schema_stats.get(input_schema_guid)
+                                        input_nrows = input_stats and input_stats.get('nrows')
+                                        if input_nrows:
+                                            delta_nrows = input_nrows - output_nrows
+                                            input_name = self.logical_name_by_guid.get(input_schema_guid, self.schema_name_by_guid.get(input_schema_guid))
+                                            clean_input_name = self.name_for_stats(input_name)
+                                            stats['delta.nrows_' + clean_input_name + '.abs']=delta_nrows
+                                            stats['delta.nrows_' + clean_input_name + '.decrease in %'] = round(100*delta_nrows/input_nrows,2)
+                                    self.schema_stats[schema_guid] = stats
+                                    self.stats_to_send[lineage_run.to_guid()][schema_guid] = stats
 
 
                         #FIXME should be using extractors instead


### PR DESCRIPTION
restore original behaviour of stats with KensuDatasourceAndSchema (was broken by https://github.com/kensuio-oss/kensu-py/commit/a5a3003309aae521974c6f06bd16a5ee95f4c2e5#diff-9641607792d025086f96af17d18b3303dcb06dde5e6179833357d79b98b7e413L476-L482  ):
  - first call .f_get_stats via `self.extract_stats(stats_df)` and try to publish stats in regular way
  - only if this returns None, call `stats_df.f_publish_stats(lineage_run.to_guid())` instead of calling `f_publish_stats` always if we've got `KensuDatasourceAndSchema` class
   
mostly just whitespace changes - https://github.com/kensuio-oss/kensu-py/pull/89/files?diff=unified&w=1


affects:
- bigquery
- psychopg
- spark
- ... ?



