### PR TITLE
Add output stats for  BigQuery DDL queries

### DIFF
--- a/kensu/google/cloud/bigquery/extractor.py
+++ b/kensu/google/cloud/bigquery/extractor.py
@@ -89,9 +89,16 @@ class KensuBigQuerySupport(ExtractorSupport):  # should extends some KensuSuppor
 
     def tk(self, k, k1): return k + '.' + k1
 
+    @staticmethod
+    def set_stats(obj, out_stats_values):
+        # store stats to be later picked up by extract_stats below
+        obj.kensu_ddl_stats_values = out_stats_values
+
     # return dict of doubles (stats)
     def extract_stats(self, df):
-        # stats definitions are computed directly in wrapper in more efficient fashion, see `query.py`
+        if hasattr(df, 'kensu_ddl_stats_values'):
+            return getattr(df, 'kensu_ddl_stats_values')
+        # otherwise, stats definitions are computed directly in wrapper in more efficient fashion, see `query.py`
         return None
 
     def extract_data_source(self, df, pl, **kwargs):

--- a/kensu/google/cloud/bigquery/job/bigquery_stats.py
+++ b/kensu/google/cloud/bigquery/job/bigquery_stats.py
@@ -15,7 +15,7 @@ def compute_bigquery_stats(table_ref=None, table=None, client=None, stats_aggs=N
     r = {}
     kensu = KensuProvider().instance()
     client: Client = client or kensu.data_collectors['BigQuery']
-    if stats_aggs is None:
+    if stats_aggs is None and table is not None:
         logger.debug('Got empty statistic listing from remote service, proceeding with fallback statistic list')
         stats_aggs = generate_fallback_stats_queries(table)
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ NAME = "kensu"
 
 BUILD_FLAVOR = os.environ["BUILD_FLAVOR"] if "BUILD_FLAVOR" in os.environ else ""
 BUILD_NUMBER = os.environ["BUILD_NUMBER"] if "BUILD_NUMBER" in os.environ else ""
-VERSION = "1.8.0.1" + BUILD_FLAVOR + BUILD_NUMBER
+VERSION = "1.8.0.2" + BUILD_FLAVOR + BUILD_NUMBER
 
 
 


### PR DESCRIPTION
for BigQuery DDL query like `CREATE OR REPLACE TABLE xyz AS SELECT *` report the output
stats by computing stats for the complete data in the table