### PR TITLE
Rename and align configuration properties with Python/PySpark/Spark-Collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,15 @@ Otherwise, the `CONF_FILE` environment variable can point to another one.
 
 ### Configuration keys
 
+https://kensu.atlassian.net/wiki/spaces/EN/pages/1109000195/Agent+-+Spark+-+Configuration
+
 #### General
 Connect to API
-- api_url
-- api_token
+- kensu_ingestion_url
+- kensu_ingestion_token
 
 Meta information about the python application
-- project_names
+- project_name
 - environment
 - process_name
 - user_name
@@ -60,15 +62,14 @@ Meta information about the python application
 
 Behavior of the data observability features
 - do_report: if False, no data observability information are reporterd
-- logical_naming: **TODO** - explain data source grouping strategies such as File, ...
-- mapping: **TODO**
+- logical_data_source_naming_strategy: - explain data source grouping strategies such as File, ...
 
 Extra libraries support (TODO: to be extracted in different modules)
 - pandas_support: Boolean
 - sklearn_support: Boolean
 - bigquery_support: Boolean
 - tensorflow_support: Boolean
-- sql_util_url: URL to an external server capable of handling SQL parsing into lineage
+- kensu_sql_parser_url: URL to an external server capable of handling SQL parsing into lineage
 
 #### Reporters
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Each reporter has its own conf keys.
 
 Dispatches to several reporters
 
-- reporters: JSON array of the repoter names, e.g. reporters["KafkaReporter", "FileReporter"] 
+- reporters: JSON array of the reporter names, e.g. reporters["KafkaReporter", "FileReporter"] 
 
 ##### name=KafkaReporter
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,6 @@ Otherwise, the `CONF_FILE` environment variable can point to another one.
 
 ### Configuration keys
 
-https://kensu.atlassian.net/wiki/spaces/EN/pages/1109000195/Agent+-+Spark+-+Configuration
-
 #### General
 Connect to API
 - kensu_ingestion_url
@@ -61,8 +59,8 @@ Meta information about the python application
 - code_location
 
 Behavior of the data observability features
-- do_report: if False, no data observability information are reporterd
-- logical_data_source_naming_strategy: - explain data source grouping strategies such as File, ...
+- do_report: if False, no data observability information are reported
+- logical_data_source_naming_strategy: **TODO** - explain data source grouping strategies such as File, ...
 
 Extra libraries support (TODO: to be extracted in different modules)
 - pandas_support: Boolean

--- a/conf.ini
+++ b/conf.ini
@@ -1,13 +1,12 @@
 [kensu]
-;api_url
-;api_token
-;project_names
+;ingestion_url
+;ingestion_token
+;project_name
 ;environment
 ;process_name
 ;user_name
 ;code_location
 ;logical_naming
-;mapping
 ;do_report
 ;report_in_mem
 ;report_to_file
@@ -17,11 +16,11 @@
 ;bigquery_support
 ;tensorflow_support
 ;matplotlib_support
-;PAT
+;api_token
 ;compute_delta
 ;input_stats
 ;raise_on_check_failure
-;sql_util_url
+;kensu_sql_parser_url
 
 
 [kensu.reporter]

--- a/conf.ini
+++ b/conf.ini
@@ -6,9 +6,8 @@
 ;process_name
 ;user_name
 ;code_location
-;logical_naming
+;logical_data_source_naming_strategy
 ;do_report
-;report_in_mem
 ;report_to_file
 ;offline_file_name
 ;pandas_support
@@ -18,7 +17,7 @@
 ;matplotlib_support
 ;kensu_api_url
 ;kensu_api_token
-;compute_delta
+;compute_delta_stats
 ;compute_input_stats
 ;raise_on_check_failure
 ;kensu_sql_parser_url

--- a/conf.ini
+++ b/conf.ini
@@ -1,6 +1,6 @@
 [kensu]
-;ingestion_url
-;ingestion_token
+;kensu_ingestion_url
+;kensu_ingestion_token
 ;project_name
 ;environment
 ;process_name
@@ -16,9 +16,10 @@
 ;bigquery_support
 ;tensorflow_support
 ;matplotlib_support
-;api_token
+;kensu_api_url
+;kensu_api_token
 ;compute_delta
-;input_stats
+;compute_input_stats
 ;raise_on_check_failure
 ;kensu_sql_parser_url
 

--- a/extra.requirements
+++ b/extra.requirements
@@ -11,7 +11,7 @@ numpy>=1.19.5:                      pandas, sklearn
 scikit-learn>=0.24.2:               sklearn
 gluonts==0.6.5:                     gluon
 boto3:                              boto
-psycopg2-binary==2.8.4:             pg
+psycopg2-binary>=2.8.4:             pg
 pglast==v3.4:                       pg
 google-cloud-bigquery>=2.26.0:      gbq
 sqlparse >= 0.4.2:                  pg, gbq

--- a/extra.requirements
+++ b/extra.requirements
@@ -11,7 +11,7 @@ numpy>=1.19.5:                      pandas, sklearn
 scikit-learn>=0.24.2:               sklearn
 gluonts==0.6.5:                     gluon
 boto3:                              boto
-psycopg2-binary>=2.8.4:             pg
+psycopg2-binary==2.9.3:             pg
 pglast==v3.4:                       pg
 google-cloud-bigquery>=2.26.0:      gbq
 sqlparse >= 0.4.2:                  pg, gbq

--- a/kensu/airflow/kensu_airflow_collector.py
+++ b/kensu/airflow/kensu_airflow_collector.py
@@ -38,8 +38,8 @@ def airflow_init_kensu(
     auth_token = Variable.get("KSU_API_TOKEN", default_var=None)
 
     KensuProvider().initKensu(
-        ingestion_url=api_url,
-        ingestion_token=auth_token,
+        kensu_ingestion_url=api_url,
+        kensu_ingestion_token=auth_token,
         init_context=True,
         project_names=project_names,
         process_name=process_name,

--- a/kensu/airflow/kensu_airflow_collector.py
+++ b/kensu/airflow/kensu_airflow_collector.py
@@ -18,13 +18,11 @@ def airflow_init_kensu(
         airflow_operator=None,  # type: BaseOperator
         project_names=None,
         process_name=None,
-        api_url=None,
-        auth_token=None,
 ):
     if airflow_operator is not None:
         if project_names is None:
             from airflow.models import Variable
-            project_names = [Variable.get("KSU_PROJECT", default_var='Airflow :: ' + airflow_operator.dag_id)]
+            project_names = [Variable.get("KSU_PROJECT_NAME", default_var='Airflow :: ' + airflow_operator.dag_id)]
         if process_name is None:
             process_name = airflow_operator.task_id
     # This must be called at each dag Operation, as Airflow operations may run on different Hosts
@@ -34,17 +32,15 @@ def airflow_init_kensu(
     # it seems GCP Composer's env variables are actually not passed (at least to some of the Airflow Operators)
     # so we set the important/sensitive settings explicitly from Airflow (secured) variables
     from airflow.models import Variable
-    api_url = Variable.get("KSU_API_URL", default_var=None)
-    auth_token = Variable.get("KSU_API_TOKEN", default_var=None)
+    api_url = Variable.get("KSU_KENSU_INGESTION_URL", default_var=None)
+    auth_token = Variable.get("KSU_KENSU_INGESTION_TOKEN", default_var=None)
 
     KensuProvider().initKensu(
         kensu_ingestion_url=api_url,
         kensu_ingestion_token=auth_token,
         init_context=True,
-        project_names=project_names,
+        project_name=project_names,
         process_name=process_name,
-        mapping=True,
-        report_in_mem=False,
         bigquery_support=True)
 
 

--- a/kensu/airflow/kensu_airflow_collector.py
+++ b/kensu/airflow/kensu_airflow_collector.py
@@ -24,7 +24,7 @@ def airflow_init_kensu(
     if airflow_operator is not None:
         if project_names is None:
             from airflow.models import Variable
-            project_names = [Variable.get("KENSU_PROJECT", default_var='Airflow :: ' + airflow_operator.dag_id)]
+            project_names = [Variable.get("KSU_PROJECT", default_var='Airflow :: ' + airflow_operator.dag_id)]
         if process_name is None:
             process_name = airflow_operator.task_id
     # This must be called at each dag Operation, as Airflow operations may run on different Hosts
@@ -34,12 +34,12 @@ def airflow_init_kensu(
     # it seems GCP Composer's env variables are actually not passed (at least to some of the Airflow Operators)
     # so we set the important/sensitive settings explicitly from Airflow (secured) variables
     from airflow.models import Variable
-    api_url = Variable.get("KENSU_API_URL", default_var=None)
-    auth_token = Variable.get("KENSU_API_TOKEN", default_var=None)
+    api_url = Variable.get("KSU_API_URL", default_var=None)
+    auth_token = Variable.get("KSU_API_TOKEN", default_var=None)
 
     KensuProvider().initKensu(
-        api_url=api_url,
-        auth_token=auth_token,
+        ingestion_url=api_url,
+        ingestion_token=auth_token,
         init_context=True,
         project_names=project_names,
         process_name=process_name,

--- a/kensu/google/cloud/bigquery/job/remote_parser.py
+++ b/kensu/google/cloud/bigquery/job/remote_parser.py
@@ -32,7 +32,7 @@ class BqRemoteParser:
     def parse(kensu, client: bq.Client, query: str, db_metadata, table_id_to_bqtable) -> GenericComputedInMemDs:
         ## POST REQUEST to /lineage-and-stats-criterions
         req = {"sql": query, "metadata": db_metadata}
-        url = kensu.sql_util_url
+        url = kensu.kensu_sql_parser_url
         logger.debug("sending request to SQL parsing service url={} request={}".format(url, str(req)))
         import requests
         def convert(fieldtype):

--- a/kensu/pyspark/spark_connector.py
+++ b/kensu/pyspark/spark_connector.py
@@ -401,7 +401,7 @@ Allowed values for parameters:
   * 'LastFolderAndFile' - b/c.ext
   * 'LastFolder' - b
   * 'PathBasedRule' - use data_source_naming_strategy_rules
-- logical_data_source_naming_strategy_rules:
+- logical_data_source_naming_strategy:
   * None (default) - do not set logical datasource
   * 'File' - c.ext
   * 'LastTwoFoldersAndFile' - a/b/c.ext
@@ -489,14 +489,14 @@ def init_kensu_spark(
 
         kensu_conf = config['kensu'] if config.has_section('kensu') else config['DEFAULT']
 
-        kensu_ingestion_url = extract_config_property('ingestion_url', None, kensu_ingestion_url, kw=kwargs, conf=kensu_conf)
-        kensu_ingestion_token = extract_config_property('ingestion_token', None, kensu_ingestion_token, kw=kwargs, conf=kensu_conf)
+        kensu_ingestion_url = extract_config_property('kensu_ingestion_url', None, kensu_ingestion_url, kw=kwargs, conf=kensu_conf)
+        kensu_ingestion_token = extract_config_property('kensu_ingestion_token', None, kensu_ingestion_token, kw=kwargs, conf=kensu_conf)
         report_to_file = extract_config_property('report_to_file', False, report_to_file, kw=kwargs, conf=kensu_conf, tpe=bool)
         logs_dir_path = extract_config_property('logs_dir_path', None, logs_dir_path, kw=kwargs, conf=kensu_conf)
         offline_file_name = extract_config_property('offline_file_name', 'kensu-offline.log', offline_file_name, kw=kwargs, conf=kensu_conf)
 
         shutdown_timeout_sec = extract_config_property('shutdown_timeout_sec', 10 * 60, shutdown_timeout_sec, kw=kwargs, conf=kensu_conf, tpe=int)
-        kensu_api_verify_ssl = extract_config_property('api_verify_ssl', True, kensu_api_verify_ssl, kw=kwargs, conf=kensu_conf, tpe=bool)
+        kensu_api_verify_ssl = extract_config_property('kensu_api_verify_ssl', True, kensu_api_verify_ssl, kw=kwargs, conf=kensu_conf, tpe=bool)
         enable_debugging = extract_config_property('enable_debugging', False, enable_debugging, kw=kwargs, conf=kensu_conf, tpe=bool)
         debugging_log_level = extract_config_property('debugging_log_level', 'INFO', debugging_log_level, kw=kwargs, conf=kensu_conf)
         debugging_include_spark_logs = extract_config_property('debugging_include_spark_logs', False, debugging_include_spark_logs, kw=kwargs, conf=kensu_conf, tpe=bool)
@@ -635,8 +635,7 @@ def init_kensu_spark(
                 properties.add(t2("offline_report_dir_path", logs_dir_path))
                 properties.add(t2("offline_file_name", join_paths(logs_dir_path, offline_file_name)))
             if kensu_api_verify_ssl is not None:
-                # renamed (and aligned from other places) from allow_invalid_ssl_certificates
-                properties.add(t2("kensu_api_verify_ssl", not kensu_api_verify_ssl))
+                properties.add(t2("kensu_api_verify_ssl", kensu_api_verify_ssl))
             if enable_entity_compaction is not None:
                 properties.add(t2("enable_entity_compaction", enable_entity_compaction))
 

--- a/kensu/pyspark/spark_connector.py
+++ b/kensu/pyspark/spark_connector.py
@@ -1,5 +1,6 @@
 import os
 import logging
+from kensu.utils.helpers import extract_config_property
 
 # This function takes the fully classified object name, say: <package>.<name>.
 # Returns the static object instance on the heap
@@ -394,25 +395,6 @@ def get_inputs_lineage_fn(dam, df):
     return GenericComputedInMemDs(inputs=list([x.input_ds for x in lineage_info]), lineage=lineage_info)
 
 
-def kwargs_or_conf_or_default(key, default, arg=None, kw=None, conf=None, tpe=None):
-    if arg is not None:
-        return arg
-    elif key in kw and kw[key] is not None:
-        return kw[key]
-    elif key in conf and conf.get(key) is not None:
-        if default is not None and tpe is None:
-            tpe = type(default)
-        r = conf.get(key)
-        if tpe is list:
-            r = r.replace(" ", "").split(",")
-        elif tpe is bool:
-            r = conf.getboolean(key)
-        elif tpe is not None:
-            r = tpe(r)
-        return r
-    else:
-        return default
-
 """
 Assuming Datasource name is /a/b/c.ext
 Allowed values for parameters:
@@ -444,23 +426,22 @@ Allowed values for parameters:
     * 'OutFieldStartsWithInFieldNameLineageStrat'
 """
 def init_kensu_spark(
-        spark=None,
+        spark_session=None,
         ingestion_url=None,
         ingestion_token=None,
-        is_offline=None,
+        report_to_file=None,
         is_dam_tracking_enabled=True,
-        dam_logs_directory=None,
-        offline_mode_file_name=None,
-        explicit_process_name=None,
-        explicit_process_run_name=None,
-        explicit_code_repo=None,
-        explicit_code_version=None,
-        explicit_code_maintainers=None,
-        explicit_lauched_by_user=None,
+        logs_dir_path=None,
+        offline_file_name=None,
+        process_name=None,
+        process_run_name=None,
+        code_location=None,
+        code_version=None,
+        user_name=None,
         enable_entity_compaction=None,
         allow_invalid_ssl_certificates=None,
-        stats=None,
-        input_stats=None,
+        compute_stats=None,
+        compute_input_stats=None,
         input_stats_for_only_used_columns=None,
         input_stats_keep_filters=None,
         input_stats_compute_quantiles=None,
@@ -473,9 +454,9 @@ def init_kensu_spark(
         output_stats_coalesce_workers=None,
         cache_output_for_datastats=None,
         use_short_datasource_names=None,
-        dam_shutdown_timeout_secs=None,
-        dam_debug_file_level=None,
-        dam_debug_file_enabled=None,
+        shutdown_timeout_secs=None,
+        debugging_log_level=None,
+        enable_debugging=None,
         datasource_short_name_strategy=None,
         datasource_short_name_strategy_rules=None,
         logical_datasource_name_strategy=None,
@@ -487,7 +468,7 @@ def init_kensu_spark(
         disable_spark_writes=None,
         environment=None,
         fake_timestamp=None,
-        projects=None,  # type: list[str]
+        project_names=None,  # type: list[str]
         project=None,
         h2o_create_virtual_training_datasource=None,
         pandas_conversions=None,
@@ -497,7 +478,7 @@ def init_kensu_spark(
 ):
     if is_dam_tracking_enabled:
         logging.info("Initializing DAM...")
-        jvm = spark.sparkContext._jvm
+        jvm = spark_session.sparkContext._jvm
 
         from configparser import ConfigParser, ExtendedInterpolation
         config = ConfigParser(interpolation=ExtendedInterpolation())
@@ -509,53 +490,58 @@ def init_kensu_spark(
 
         kensu_conf = config['kensu'] if config.has_section('kensu') else config['DEFAULT']
 
-        ingestion_url = kwargs_or_conf_or_default('api_url',None,ingestion_url, kw=kwargs, conf=kensu_conf)
-        ingestion_token = kwargs_or_conf_or_default('api_token',None,ingestion_token, kw=kwargs, conf=kensu_conf)
-        is_offline = kwargs_or_conf_or_default('is_offline',False,is_offline, kw=kwargs, conf=kensu_conf, tpe=bool)
-        dam_logs_directory = kwargs_or_conf_or_default('dam_logs_directory',None,dam_logs_directory, kw=kwargs, conf=kensu_conf)
-        offline_mode_file_name = kwargs_or_conf_or_default('offline_mode_file_name','dam-offline.log',offline_mode_file_name, kw=kwargs, conf=kensu_conf)
-        explicit_process_name = kwargs_or_conf_or_default('process_name',None,explicit_process_name, kw=kwargs, conf=kensu_conf)
-        explicit_process_run_name = kwargs_or_conf_or_default('explicit_process_run_name',None,explicit_process_run_name, kw=kwargs, conf=kensu_conf)
-        explicit_code_repo = kwargs_or_conf_or_default('explicit_code_repo',None,explicit_code_repo, kw=kwargs, conf=kensu_conf)
-        explicit_code_version = kwargs_or_conf_or_default('explicit_code_version',None,explicit_code_version, kw=kwargs, conf=kensu_conf)
-        explicit_code_maintainers = kwargs_or_conf_or_default('explicit_code_maintainers',None,explicit_code_maintainers, kw=kwargs, conf=kensu_conf)
-        explicit_lauched_by_user = kwargs_or_conf_or_default('explicit_lauched_by_user',None,explicit_lauched_by_user, kw=kwargs, conf=kensu_conf)
-        enable_entity_compaction = kwargs_or_conf_or_default('enable_entity_compaction',True,enable_entity_compaction, kw=kwargs, conf=kensu_conf, tpe=bool)
-        allow_invalid_ssl_certificates = kwargs_or_conf_or_default('allow_invalid_ssl_certificates',False,allow_invalid_ssl_certificates, kw=kwargs, conf=kensu_conf, tpe=bool)
-        stats = kwargs_or_conf_or_default('stats',True,stats, kw=kwargs, conf=kensu_conf, tpe=bool)
-        input_stats = kwargs_or_conf_or_default('input_stats',True,input_stats, kw=kwargs, conf=kensu_conf, tpe=bool)
-        input_stats_for_only_used_columns = kwargs_or_conf_or_default('input_stats_for_only_used_columns',True,input_stats_for_only_used_columns, kw=kwargs, conf=kensu_conf, tpe=bool)
-        input_stats_keep_filters = kwargs_or_conf_or_default('input_stats_keep_filters',True,input_stats_keep_filters, kw=kwargs, conf=kensu_conf, tpe=bool)
-        input_stats_compute_quantiles =  kwargs_or_conf_or_default('input_stats_compute_quantiles',False,input_stats_compute_quantiles, kw=kwargs, conf=kensu_conf, tpe=bool)
-        input_stats_cache_bypath = kwargs_or_conf_or_default('input_stats_cache_bypath',True,input_stats_cache_bypath, kw=kwargs, conf=kensu_conf, tpe=bool)
-        input_stats_coalesce_enabled = kwargs_or_conf_or_default('input_stats_coalesce_enabled',True,input_stats_coalesce_enabled, kw=kwargs, conf=kensu_conf, tpe=bool)
-        input_stats_coalesce_workers = kwargs_or_conf_or_default('input_stats_coalesce_workers',1,input_stats_coalesce_workers, kw=kwargs, conf=kensu_conf, tpe=int)
-        output_stats_compute_quantiles = kwargs_or_conf_or_default('output_stats_compute_quantiles',False,output_stats_compute_quantiles, kw=kwargs, conf=kensu_conf, tpe=bool)
-        output_stats_cache_bypath =  kwargs_or_conf_or_default('output_stats_cache_bypath',False,output_stats_cache_bypath, kw=kwargs, conf=kensu_conf, tpe=bool)
-        output_stats_coalesce_enabled = kwargs_or_conf_or_default('output_stats_coalesce_enabled',False,output_stats_coalesce_enabled, kw=kwargs, conf=kensu_conf, tpe=bool)
-        output_stats_coalesce_workers = kwargs_or_conf_or_default('output_stats_coalesce_workers',100,output_stats_coalesce_workers, kw=kwargs, conf=kensu_conf, tpe=int)
-        cache_output_for_datastats = kwargs_or_conf_or_default('cache_output_for_datastats',False,cache_output_for_datastats, kw=kwargs, conf=kensu_conf, tpe=bool)
-        use_short_datasource_names = kwargs_or_conf_or_default('use_short_datasource_names',True,use_short_datasource_names, kw=kwargs, conf=kensu_conf, tpe=bool)
-        dam_shutdown_timeout_secs = kwargs_or_conf_or_default('dam_shutdown_timeout_secs',10 * 60,dam_shutdown_timeout_secs, kw=kwargs, conf=kensu_conf, tpe=int)
-        dam_debug_file_level =  kwargs_or_conf_or_default('dam_debug_file_level','INFO',dam_debug_file_level, kw=kwargs, conf=kensu_conf)
-        dam_debug_file_enabled = kwargs_or_conf_or_default('dam_debug_file_enabled',False,dam_debug_file_enabled, kw=kwargs, conf=kensu_conf, tpe=bool)
-        datasource_short_name_strategy = kwargs_or_conf_or_default('datasource_short_name_strategy',None,datasource_short_name_strategy, kw=kwargs, conf=kensu_conf)
-        datasource_short_name_strategy_rules = kwargs_or_conf_or_default('datasource_short_name_strategy_rules',None,datasource_short_name_strategy_rules, kw=kwargs, conf=kensu_conf)
-        logical_datasource_name_strategy = kwargs_or_conf_or_default('logical_naming',None,logical_datasource_name_strategy, kw=kwargs, conf=kensu_conf)
-        logical_datasource_name_strategy_rules = kwargs_or_conf_or_default('logical_datasource_name_strategy_rules',None,logical_datasource_name_strategy_rules, kw=kwargs, conf=kensu_conf)
-        lineage_missing_fallback_strategy = kwargs_or_conf_or_default('lineage_missing_fallback_strategy',None,lineage_missing_fallback_strategy, kw=kwargs, conf=kensu_conf)
-        capture_spark_logs = kwargs_or_conf_or_default('capture_spark_logs',False,capture_spark_logs, kw=kwargs, conf=kensu_conf, tpe=bool)
-        h2o = kwargs_or_conf_or_default('h2o',False,h2o, kw=kwargs, conf=kensu_conf, tpe=bool)
-        add_dam_dataframe_helpers = kwargs_or_conf_or_default('add_dam_dataframe_helpers',True,add_dam_dataframe_helpers, kw=kwargs, conf=kensu_conf, tpe=bool)
-        disable_spark_writes = kwargs_or_conf_or_default('disable_spark_writes',False,disable_spark_writes, kw=kwargs, conf=kensu_conf, tpe=bool)
-        environment =  kwargs_or_conf_or_default('environment',None,environment, kw=kwargs, conf=kensu_conf)
-        fake_timestamp =  kwargs_or_conf_or_default('fake_timestamp',None,fake_timestamp, kw=kwargs, conf=kensu_conf,tpe=int)
-        projects =  kwargs_or_conf_or_default('projects',None,projects, kw=kwargs, conf=kensu_conf,tpe=list)  # type: list[str]
-        project =  kwargs_or_conf_or_default('project_names',None,project, kw=kwargs, conf=kensu_conf)
-        h2o_create_virtual_training_datasource = kwargs_or_conf_or_default('h2o_create_virtual_training_datasource',True,h2o_create_virtual_training_datasource, kw=kwargs, conf=kensu_conf, tpe=bool)
-        pandas_conversions = kwargs_or_conf_or_default('pandas_conversions',True,pandas_conversions, kw=kwargs, conf=kensu_conf, tpe=bool)
-        pandas_to_spark_df_via_tmp_file = kwargs_or_conf_or_default('pandas_to_spark_df_via_tmp_file',True,pandas_to_spark_df_via_tmp_file, kw=kwargs, conf=kensu_conf, tpe=bool)
-        pandas_to_spark_tmp_dir = kwargs_or_conf_or_default('pandas_to_spark_tmp_dir','/tmp/spark-to-pandas-tmp',pandas_to_spark_tmp_dir, kw=kwargs, conf=kensu_conf)
+        ingestion_url = extract_config_property('ingestion_url',None,ingestion_url, kw=kwargs, conf=kensu_conf)
+        ingestion_token = extract_config_property('ingestion_token',None,ingestion_token, kw=kwargs, conf=kensu_conf)
+        report_to_file = extract_config_property('report_to_file', False, report_to_file, kw=kwargs, conf=kensu_conf, tpe=bool)
+        logs_dir_path = extract_config_property('logs_dir_path', None, logs_dir_path, kw=kwargs, conf=kensu_conf)
+        offline_file_name = extract_config_property('offline_file_name', 'dam-offline.log', offline_file_name, kw=kwargs, conf=kensu_conf)
+        process_name = extract_config_property('process_name', None, process_name, kw=kwargs, conf=kensu_conf)
+        process_run_name = extract_config_property('process_run_name', None, process_run_name, kw=kwargs, conf=kensu_conf)
+        code_location = extract_config_property('code_location', None, code_location, kw=kwargs, conf=kensu_conf)
+        code_version = extract_config_property('code_version', None, code_version, kw=kwargs, conf=kensu_conf)
+        user_name = extract_config_property('user_name', None, user_name, kw=kwargs, conf=kensu_conf)
+        enable_entity_compaction = extract_config_property('enable_entity_compaction',True,enable_entity_compaction, kw=kwargs, conf=kensu_conf, tpe=bool)
+
+        # TODO api_verify_ssl ?
+        allow_invalid_ssl_certificates = extract_config_property('allow_invalid_ssl_certificates',False,allow_invalid_ssl_certificates, kw=kwargs, conf=kensu_conf, tpe=bool)
+
+        compute_stats = extract_config_property('compute_stats', True, compute_stats, kw=kwargs, conf=kensu_conf, tpe=bool)
+        compute_input_stats = extract_config_property('compute_input_stats', True, compute_input_stats, kw=kwargs, conf=kensu_conf, tpe=bool)
+        input_stats_for_only_used_columns = extract_config_property('input_stats_for_only_used_columns',True,input_stats_for_only_used_columns, kw=kwargs, conf=kensu_conf, tpe=bool)
+        input_stats_keep_filters = extract_config_property('input_stats_keep_filters',True,input_stats_keep_filters, kw=kwargs, conf=kensu_conf, tpe=bool)
+        input_stats_compute_quantiles = extract_config_property('input_stats_compute_quantiles',False,input_stats_compute_quantiles, kw=kwargs, conf=kensu_conf, tpe=bool)
+        input_stats_cache_bypath = extract_config_property('input_stats_cache_bypath',True,input_stats_cache_bypath, kw=kwargs, conf=kensu_conf, tpe=bool)
+        input_stats_coalesce_enabled = extract_config_property('input_stats_coalesce_enabled',True,input_stats_coalesce_enabled, kw=kwargs, conf=kensu_conf, tpe=bool)
+        input_stats_coalesce_workers = extract_config_property('input_stats_coalesce_workers',1,input_stats_coalesce_workers, kw=kwargs, conf=kensu_conf, tpe=int)
+        output_stats_compute_quantiles = extract_config_property('output_stats_compute_quantiles',False,output_stats_compute_quantiles, kw=kwargs, conf=kensu_conf, tpe=bool)
+        output_stats_cache_bypath = extract_config_property('output_stats_cache_bypath',False,output_stats_cache_bypath, kw=kwargs, conf=kensu_conf, tpe=bool)
+        output_stats_coalesce_enabled = extract_config_property('output_stats_coalesce_enabled',False,output_stats_coalesce_enabled, kw=kwargs, conf=kensu_conf, tpe=bool)
+        output_stats_coalesce_workers = extract_config_property('output_stats_coalesce_workers',100,output_stats_coalesce_workers, kw=kwargs, conf=kensu_conf, tpe=int)
+        cache_output_for_datastats = extract_config_property('cache_output_for_datastats',False,cache_output_for_datastats, kw=kwargs, conf=kensu_conf, tpe=bool)
+
+        use_short_datasource_names = extract_config_property('use_short_datasource_names',True,use_short_datasource_names, kw=kwargs, conf=kensu_conf, tpe=bool)
+
+        shutdown_timeout_secs = extract_config_property('shutdown_timeout_secs', 10 * 60, shutdown_timeout_secs, kw=kwargs, conf=kensu_conf, tpe=int)
+        enable_debugging = extract_config_property('enable_debugging', False, enable_debugging, kw=kwargs, conf=kensu_conf, tpe=bool)
+        debugging_log_level = extract_config_property('debugging_log_level', 'INFO', debugging_log_level, kw=kwargs, conf=kensu_conf)
+
+        datasource_short_name_strategy = extract_config_property('datasource_short_name_strategy',None,datasource_short_name_strategy, kw=kwargs, conf=kensu_conf)
+        datasource_short_name_strategy_rules = extract_config_property('datasource_short_name_strategy_rules',None,datasource_short_name_strategy_rules, kw=kwargs, conf=kensu_conf)
+        logical_datasource_name_strategy = extract_config_property('logical_naming',None,logical_datasource_name_strategy, kw=kwargs, conf=kensu_conf)
+        logical_datasource_name_strategy_rules = extract_config_property('logical_datasource_name_strategy_rules',None,logical_datasource_name_strategy_rules, kw=kwargs, conf=kensu_conf)
+        lineage_missing_fallback_strategy = extract_config_property('lineage_missing_fallback_strategy',None,lineage_missing_fallback_strategy, kw=kwargs, conf=kensu_conf)
+        capture_spark_logs = extract_config_property('capture_spark_logs',False,capture_spark_logs, kw=kwargs, conf=kensu_conf, tpe=bool)
+        h2o = extract_config_property('h2o',False,h2o, kw=kwargs, conf=kensu_conf, tpe=bool)
+        add_dam_dataframe_helpers = extract_config_property('add_dam_dataframe_helpers',True,add_dam_dataframe_helpers, kw=kwargs, conf=kensu_conf, tpe=bool)
+        disable_spark_writes = extract_config_property('disable_spark_writes',False,disable_spark_writes, kw=kwargs, conf=kensu_conf, tpe=bool)
+        environment =  extract_config_property('environment',None,environment, kw=kwargs, conf=kensu_conf)
+        fake_timestamp =  extract_config_property('fake_timestamp',None,fake_timestamp, kw=kwargs, conf=kensu_conf,tpe=int)
+        project_names =  extract_config_property('projects', None, project_names, kw=kwargs, conf=kensu_conf, tpe=list)  # type: list[str]
+        project =  extract_config_property('project_names',None,project, kw=kwargs, conf=kensu_conf)
+        h2o_create_virtual_training_datasource = extract_config_property('h2o_create_virtual_training_datasource',True,h2o_create_virtual_training_datasource, kw=kwargs, conf=kensu_conf, tpe=bool)
+        pandas_conversions = extract_config_property('pandas_conversions',True,pandas_conversions, kw=kwargs, conf=kensu_conf, tpe=bool)
+        pandas_to_spark_df_via_tmp_file = extract_config_property('pandas_to_spark_df_via_tmp_file',True,pandas_to_spark_df_via_tmp_file, kw=kwargs, conf=kensu_conf, tpe=bool)
+        pandas_to_spark_tmp_dir = extract_config_property('pandas_to_spark_tmp_dir','/tmp/spark-to-pandas-tmp',pandas_to_spark_tmp_dir, kw=kwargs, conf=kensu_conf)
 
 
         try:
@@ -586,9 +572,9 @@ def init_kensu_spark(
                             warnings.simplefilter("ignore", category=ShimWarning)
                             from IPython.html.notebookapp import list_running_servers
                     except ImportError:  # Probably pyspark script is run without IPython/Jupyter
-                        if not explicit_process_name:
+                        if not process_name:
                             logging.warning('WARN Unable to automatically extract Jupyter/pyspark notebook name (did you run it without jupyter?)')
-                        return ['', explicit_process_name or 'Unknown pyspark filename']
+                        return ['', process_name or 'Unknown pyspark filename']
                 try:
                     import ipykernel
                     kernel_id = re.search('kernel-(.*).json',
@@ -603,9 +589,9 @@ def init_kensu_spark(
                                 notebooks_path = server['notebook_dir']
                                 return [notebooks_path, nn['notebook']['path']]
                 except Exception as e:
-                    if not explicit_process_name:
+                    if not process_name:
                         logging.warning('WARN Unable to automatically extract pyspark notebook name')
-                    return ['', explicit_process_name or 'Unknown pyspark filename']
+                    return ['', process_name or 'Unknown pyspark filename']
 
             notebooks_path, notebook_name = get_notebook_name()
             logging.info("Notebook name " + notebook_name)
@@ -618,32 +604,25 @@ def init_kensu_spark(
             t2 = jvm.scala.Tuple2
             providerClassName = t2("dam.activity.spark.environnement.provider", "io.kensu.dam.lineage.spark.lineage.DefaultSparkEnvironnementProvider")
 
-            if isinstance(explicit_code_maintainers, str):
-                explicit_code_maintainers = [explicit_code_maintainers]
-            user_names = explicit_code_maintainers or [os.environ.get("USER", "jupyter-notebook")]
-            global dam_user_name   # FIXME: why do we need this global? I think we don't?
-            jlist = jvm.java.util.ArrayList()
-            for user_name in user_names:
-                jlist.add(user_name)
-                dam_user_name = user_name
-            maintainers = t2("dam.activity.code.maintainers", jlist)
             ### How to get GIT info here?
             #         explicit_code_repo=None,
             #         explicit_code_version=None,
             #         explicit_code_maintainers=None,
             #         explicit_lauched_by_user=None,
-            code_repo_name = explicit_code_repo or os.environ.get("DAM_CODE_REPOSITORY", "Jupyter-Notebook:spark-" + spark.version+"::"+notebooks_path)
+            code_repo_name = code_location or os.environ.get("DAM_CODE_REPOSITORY", "Jupyter-Notebook:spark-" + spark_session.version + "::" + notebooks_path)
             repository = t2("dam.activity.code.repository", code_repo_name)
             from datetime import datetime
             d = datetime.now()
 
-            code_version_value = explicit_code_version or os.environ.get("DAM_CODE_VERSION", notebook_name + "::" + str(d))
+            code_version_value = code_version or os.environ.get("DAM_CODE_VERSION", notebook_name + "::" + str(d))
             version = t2("dam.activity.code.version", code_version_value)
 
             global dam_version
             dam_version = code_version_value
-            user = t2("dam.activity.user", explicit_lauched_by_user or dam_user_name)
-            organization = t2("dam.activity.organization", "Unknown")
+            user = t2("dam.activity.user", user_name)
+
+            organization = t2("dam.activity.organization", "Unknown")  # TODO this is not used by Scala side
+
             properties = jvm.scala.collection.mutable.HashSet()
 
             def add_prop(name, value):
@@ -651,26 +630,25 @@ def init_kensu_spark(
                     properties.add(t2(name, value))
 
             properties.add(providerClassName)
-            properties.add(maintainers)
             properties.add(repository)
             properties.add(version)
             properties.add(user)
             properties.add(organization)
             if ingestion_token:
                 properties.add(t2("dam.ingestion.auth.token", ingestion_token))
-            if is_offline is not None:
-                properties.add(t2("dam.ingestion.is_offline", is_offline))
-            if offline_mode_file_name:
-                properties.add(t2("dam.ingestion.offline.file", join_paths(dam_logs_directory, offline_mode_file_name)))
+            if report_to_file is not None:
+                properties.add(t2("dam.ingestion.is_offline", report_to_file))
+            if offline_file_name:
+                properties.add(t2("dam.ingestion.offline.file", join_paths(logs_dir_path, offline_file_name)))
             if allow_invalid_ssl_certificates is not None:
                 properties.add(t2("dam.ingestion.ignore.ssl.cert", allow_invalid_ssl_certificates))
             if enable_entity_compaction is not None:
                 properties.add(t2("dam.ingestion.entity.compaction", enable_entity_compaction))
 
-            if stats is not None:
-                properties.add(t2("dam.spark.data_stats.enabled", stats))
-            if input_stats is not None:
-                properties.add(t2("dam.spark.data_stats.input.enabled", input_stats))
+            if compute_stats is not None:
+                properties.add(t2("dam.spark.data_stats.enabled", compute_stats))
+            if compute_input_stats is not None:
+                properties.add(t2("dam.spark.data_stats.input.enabled", compute_input_stats))
             if input_stats_for_only_used_columns:
                 properties.add(t2("dam.spark.data_stats.input.only_used_in_lineage", input_stats_for_only_used_columns))
             if input_stats_keep_filters is not None:
@@ -686,15 +664,15 @@ def init_kensu_spark(
             add_prop("dam.spark.data_stats.output.coalesceEnabled", output_stats_coalesce_enabled)
             add_prop("dam.spark.data_stats.output.coalesceWorkers", output_stats_coalesce_workers)
 
-            if dam_shutdown_timeout_secs is not None:
-                properties.add(t2("dam.spark.shutdown_timeout", dam_shutdown_timeout_secs))
-            if dam_debug_file_enabled:
-                debug_level = dam_debug_file_level or "INFO"
-                if explicit_process_name is not None:
-                    dam_debug_filename = join_paths(dam_logs_directory,explicit_process_name + ".dam-collector-debug.log")
+            if shutdown_timeout_secs is not None:
+                properties.add(t2("dam.spark.shutdown_timeout", shutdown_timeout_secs))
+            if enable_debugging:
+                debug_level = debugging_log_level or "INFO"
+                if process_name is not None:
+                    dam_debug_filename = join_paths(logs_dir_path, process_name + ".kensu-collector-debug.log")
                 else:
                     notebook_file_name = notebook_name.split('/')[-1].split('\\')[-1]  # remove path from notebook name
-                    dam_debug_filename = join_paths(dam_logs_directory,notebook_file_name + ".dam-collector-debug.log")
+                    dam_debug_filename = join_paths(logs_dir_path, notebook_file_name + ".kensu-collector-debug.log")
                 properties.add(t2("dam.spark.file_debug.level", debug_level))
                 properties.add(t2("dam.spark.file_debug.file_name", dam_debug_filename))
                 properties.add(t2("dam.spark.file_debug.capture_spark_logs", capture_spark_logs))
@@ -720,47 +698,47 @@ def init_kensu_spark(
                 properties.add(t2("dam.logical.datasources.naming_strategy", logical_datasource_name_strategy))
             if environment is not None:
                 properties.add(t2("dam.activity.environment", environment))
-            if projects is not None:
-                properties.add(t2("dam.activity.projects", projects))
+            if project_names is not None:
+                properties.add(t2("dam.activity.projects", project_names))
             elif project is not None:
                 properties.add(t2("dam.activity.projects", [project]))
 
             process_name = None
-            if explicit_process_name is not None:
-                process_name = explicit_process_name
+            if process_name is not None:
+                process_name = process_name
             elif notebook_name != 'Unknown pyspark filename':
                 process_name = notebook_name
             if process_name is not None:
                 properties.add(t2("dam.activity.explicit.process.name", process_name))
 
-            if explicit_process_run_name is not None:
+            if process_run_name is not None:
                 properties.add(t2("dam.activity.explicit.process_run.name", process_name))
 
             maybe_fake_timestamp = fake_timestamp or os.environ.get('DAM_OVERRIDE_TIMESTAMP')
             if maybe_fake_timestamp is not None:
-                set_fake_timestamp(spark, maybe_fake_timestamp)
+                set_fake_timestamp(spark_session, maybe_fake_timestamp)
             maybe_ds_path_sanitizer_search = os.environ.get('DAM_DS_PATH_SANITIZER_SEARCH')
             maybe_ds_path_sanitizer_replace = os.environ.get('DAM_DS_PATH_SANITIZER_REPLACE')
             if (maybe_ds_path_sanitizer_search is not None) and (maybe_ds_path_sanitizer_replace is not None):
-                add_ds_path_sanitizer(spark, maybe_ds_path_sanitizer_search, maybe_ds_path_sanitizer_replace)
+                add_ds_path_sanitizer(spark_session, maybe_ds_path_sanitizer_search, maybe_ds_path_sanitizer_replace)
 
-            w = jvm.io.kensu.dam.lineage.spark.lineage.Implicits.SparkSessionDAMWrapper(spark._jsparkSession)
+            w = jvm.io.kensu.dam.lineage.spark.lineage.Implicits.SparkSessionDAMWrapper(spark_session._jsparkSession)
             w.track(damIngestionUrl, jvm.scala.Option.empty(), properties.toSeq())
 
-            if (dam_shutdown_timeout_secs is not None) and (dam_shutdown_timeout_secs > 0):
+            if (shutdown_timeout_secs is not None) and (shutdown_timeout_secs > 0):
                 logging.info('patching spark.stop to wait for DAM reporting to finish')
                 from pyspark.sql import SparkSession
-                SparkSession.stop = patched_spark_stop(SparkSession.stop, dam_shutdown_timeout_secs)
+                SparkSession.stop = patched_spark_stop(SparkSession.stop, shutdown_timeout_secs)
                 logging.info('patching spark.stop done')
 
             if disable_spark_writes:
                 try:
-                    do_disable_spark_writes(spark)
+                    do_disable_spark_writes(spark_session)
                 except:
                     import traceback
                     logging.info("unexpected issue when disabling df.write {}".format(traceback.format_exc()))
 
-            if cache_output_for_datastats and stats:
+            if cache_output_for_datastats and compute_stats:
                 try:
                     logging.info('patching DataFrame.write to cache/persist the results to speedup data-stats computation')
                     from pyspark.sql import DataFrame
@@ -800,9 +778,9 @@ def init_kensu_spark(
                     logging.info("unexpected issue when patching DataFrame.toPandas: {}".format(traceback.format_exc()))
                 try:
                     logging.info('adding spark env var spark.executorEnv.KSU_DISABLE_PY_COLLECTOR=true'
-                          ' to disable kensu-py collector on executor nodes')
-                    spark.conf.set("spark.executorEnv.KSU_DISABLE_PY_COLLECTOR", 'true')
-                    spark.sparkContext.environment['KSU_DISABLE_PY_COLLECTOR'] = 'true'
+                                 ' to disable kensu-py collector on executor nodes')
+                    spark_session.conf.set("spark.executorEnv.KSU_DISABLE_PY_COLLECTOR", 'true')
+                    spark_session.sparkContext.environment['KSU_DISABLE_PY_COLLECTOR'] = 'true'
                     logging.info('done adding spark.executorEnv.KSU_DISABLE_PY_COLLECTOR')
                 except:
                     import traceback
@@ -821,11 +799,11 @@ def init_kensu_spark(
                 except ImportError:
                     from dam_h2o_collector import dam_patch_h2o
 
-                if dam_logs_directory is not None:
-                    dam_patch_h2o(log_file_prefix=explicit_process_name or '',
+                if logs_dir_path is not None:
+                    dam_patch_h2o(log_file_prefix=process_name or '',
                                   debug_file_enabled=True,
                                   debug_stdout_enabled=True,
-                                  dam_logs_directory=dam_logs_directory,
+                                  dam_logs_directory=logs_dir_path,
                                   create_virtual_training_datasource=h2o_create_virtual_training_datasource)
                 else:
                     dam_patch_h2o(debug_file_enabled=False,

--- a/kensu/pyspark/spark_connector.py
+++ b/kensu/pyspark/spark_connector.py
@@ -632,7 +632,7 @@ def init_kensu_spark(
             if report_to_file is not None:
                 properties.add(t2("report_to_file", report_to_file))
             if offline_file_name:
-                properties.add(t2("logs_dir_path", logs_dir_path))
+                properties.add(t2("offline_report_dir_path", logs_dir_path))
                 properties.add(t2("offline_file_name", join_paths(logs_dir_path, offline_file_name)))
             if kensu_api_verify_ssl is not None:
                 # renamed (and aligned from other places) from allow_invalid_ssl_certificates
@@ -643,7 +643,7 @@ def init_kensu_spark(
             if compute_stats is not None:
                 properties.add(t2("compute_stats", compute_stats))
             if compute_input_stats is not None:
-                properties.add(t2("dam.spark.data_stats.input.enabled", compute_input_stats))
+                properties.add(t2("compute_input_stats", compute_input_stats))
             if compute_output_stats is not None:
                 properties.add(t2("compute_output_stats", compute_output_stats))
             if input_stats_for_only_used_columns:
@@ -651,52 +651,52 @@ def init_kensu_spark(
             if input_stats_keep_filters is not None:
                 properties.add(t2("input_stats_keep_filters", input_stats_keep_filters))
 
-            add_prop("dam.spark.data_stats.input.computeQuantiles", input_stats_compute_quantiles)
-            add_prop("dam.spark.data_stats.input.cachePerPath", input_stats_cache_by_path)
-            add_prop("dam.spark.data_stats.input.coalesceEnabled", input_stats_coalesce_enabled)
-            add_prop("dam.spark.data_stats.input.coalesceWorkers", input_stats_coalesce_workers)
+            add_prop("input_stats_compute_quantiles", input_stats_compute_quantiles)
+            add_prop("input_stats_cache_by_path", input_stats_cache_by_path)
+            add_prop("input_stats_coalesce_enabled", input_stats_coalesce_enabled)
+            add_prop("input_stats_coalesce_workers", input_stats_coalesce_workers)
 
-            add_prop("dam.spark.data_stats.output.computeQuantiles", output_stats_compute_quantiles)
-            add_prop("dam.spark.data_stats.output.cachePerPath", output_stats_cache_by_path)
-            add_prop("dam.spark.data_stats.output.coalesceEnabled", output_stats_coalesce_enabled)
-            add_prop("dam.spark.data_stats.output.coalesceWorkers", output_stats_coalesce_workers)
+            add_prop("output_stats_compute_quantiles", output_stats_compute_quantiles)
+            add_prop("output_stats_cache_by_path", output_stats_cache_by_path)
+            add_prop("output_stats_coalesce_enabled", output_stats_coalesce_enabled)
+            add_prop("output_stats_coalesce_workers", output_stats_coalesce_workers)
 
             if shutdown_timeout_sec is not None:
-                properties.add(t2("dam.spark.shutdown_timeout", shutdown_timeout_sec))
+                properties.add(t2("shutdown_timeout_sec", shutdown_timeout_sec))
             if enable_debugging:
                 debug_level = debugging_log_level or "INFO"
                 if process_name is not None:
-                    dam_debug_filename = join_paths(logs_dir_path, process_name + ".kensu-collector-debug.log")
+                    kensu_debug_filename = join_paths(logs_dir_path, process_name + ".kensu-collector.log")
                 else:
                     notebook_file_name = notebook_name.split('/')[-1].split('\\')[-1]  # remove path from notebook name
-                    dam_debug_filename = join_paths(logs_dir_path, notebook_file_name + ".kensu-collector-debug.log")
-                properties.add(t2("dam.spark.file_debug.level", debug_level))
-                properties.add(t2("dam.spark.file_debug.file_name", dam_debug_filename))
+                    kensu_debug_filename = join_paths(logs_dir_path, notebook_file_name + ".kensu-collector.log")
+                properties.add(t2("debugging_log_level", debug_level))
+                properties.add(t2("debugging_file_path", kensu_debug_filename))
                 properties.add(t2("dam.spark.file_debug.capture_spark_logs", debugging_include_spark_logs))
-                logging.info("Will write dam DAM log to file:" + dam_debug_filename)
+                logging.info("Will write dam DAM log to file: " + kensu_debug_filename)
             if shorten_data_source_names is not None:
-                properties.add(t2("dam.datasources.short.name", shorten_data_source_names))
+                properties.add(t2("shorten_data_source_names", shorten_data_source_names))
 
             if data_source_naming_strategy_rules is not None:
                 data_source_naming_strategy = 'PathBasedRule'
                 converted_rules = convert_naming_rules(data_source_naming_strategy_rules)
-                properties.add(t2("dam.datasources.path_rules.short.naming_strategy", converted_rules))
+                properties.add(t2("data_source_naming_strategy_rules", converted_rules))
             if logical_data_source_naming_strategy_rules is not None:
                 logical_data_source_naming_strategy = 'PathBasedRule'
                 converted_rules = convert_naming_rules(logical_data_source_naming_strategy_rules)
-                properties.add(t2("dam.logical.datasources.path_rules.naming_strategy", converted_rules))
+                properties.add(t2("logical_data_source_naming_strategy_rules", converted_rules))
 
             if missing_column_lineage_strategy is not None:
-                properties.add(t2('dam.spark.lineage.column_lineage_fallback_strategy', missing_column_lineage_strategy))
+                properties.add(t2('missing_column_lineage_strategy', missing_column_lineage_strategy))
 
             if data_source_naming_strategy is not None:
-                properties.add(t2("dam.datasources.short.naming_strategy", data_source_naming_strategy))
+                properties.add(t2("data_source_naming_strategy", data_source_naming_strategy))
             if logical_data_source_naming_strategy is not None:
-                properties.add(t2("dam.logical.datasources.naming_strategy", logical_data_source_naming_strategy))
+                properties.add(t2("logical_data_source_naming_strategy", logical_data_source_naming_strategy))
             if environment is not None:
-                properties.add(t2("dam.activity.environment", environment))
+                properties.add(t2("environment", environment))
             if project_name is not None:
-                properties.add(t2("dam.activity.projects", project_name))
+                properties.add(t2("project_name", project_name))
 
             process_name = None
             if process_name is not None:
@@ -704,16 +704,16 @@ def init_kensu_spark(
             elif notebook_name != 'Unknown pyspark filename':
                 process_name = notebook_name
             if process_name is not None:
-                properties.add(t2("dam.activity.explicit.process.name", process_name))
+                properties.add(t2("process_name", process_name))
 
             if process_run_name is not None:
-                properties.add(t2("dam.activity.explicit.process_run.name", process_name))
+                properties.add(t2("process_run_name", process_run_name))
 
             maybe_fake_timestamp = execution_timestamp
             if maybe_fake_timestamp is not None:
                 set_fake_timestamp(spark_session, maybe_fake_timestamp)
-            maybe_ds_path_sanitizer_search = os.environ.get('DAM_DS_PATH_SANITIZER_SEARCH')
-            maybe_ds_path_sanitizer_replace = os.environ.get('DAM_DS_PATH_SANITIZER_REPLACE')
+            maybe_ds_path_sanitizer_search = os.environ.get('KSU_DS_PATH_SANITIZER_SEARCH')
+            maybe_ds_path_sanitizer_replace = os.environ.get('KSU_DS_PATH_SANITIZER_REPLACE')
             if (maybe_ds_path_sanitizer_search is not None) and (maybe_ds_path_sanitizer_replace is not None):
                 add_ds_path_sanitizer(spark_session, maybe_ds_path_sanitizer_search, maybe_ds_path_sanitizer_replace)
 

--- a/kensu/utils/helpers.py
+++ b/kensu/utils/helpers.py
@@ -1,6 +1,7 @@
 import logging
 import re
 from hashlib import sha1
+import os
 
 # fixme: circular import, so need to inline in each fn?
 # from kensu.utils.kensu_provider import KensuProvider
@@ -201,3 +202,34 @@ def extract_short_json_schema(result, result_ds):
 
     short_result_sc = Schema(name="short-schema:" + result_ds.name, pk=sc_pk)
     return short_result_sc
+
+def extract_config_property(key, default, arg=None, kw=None, conf=None, tpe=None):
+    """
+    Looks for a property value following this precedence:
+      arg > kwargs > conf > env_var > default
+    The default value is used to determine the type of the conf value (it can be overridden by tpe).
+    The environment variable will be looked up based on the pattern of `KSU_<upper-key>`.
+    """
+
+    if arg is not None:
+        return arg
+    elif key in kw and kw[key] is not None:
+        return kw[key]
+    elif key in conf and conf.get(key) is not None:
+        if default is not None and tpe is None:
+            tpe = type(default)
+        r = conf.get(key)
+        if tpe is list:
+            r = r.replace(" ", "").split(",")
+        elif tpe is bool:
+            r = conf.getboolean(key)
+        elif tpe is not None:
+            r = tpe(r)
+        return r
+    elif os.environ.get("KSU_" + key.upper()) is not None:
+        env_var = os.environ.get(key)
+        if tpe is not None:
+            env_var = tpe(env_var)
+        return env_var
+    else:
+        return default

--- a/kensu/utils/helpers.py
+++ b/kensu/utils/helpers.py
@@ -203,6 +203,7 @@ def extract_short_json_schema(result, result_ds):
     short_result_sc = Schema(name="short-schema:" + result_ds.name, pk=sc_pk)
     return short_result_sc
 
+
 def extract_config_property(key, default, arg=None, kw=None, conf=None, tpe=None):
     """
     Looks for a property value following this precedence:
@@ -233,3 +234,7 @@ def extract_config_property(key, default, arg=None, kw=None, conf=None, tpe=None
         return env_var
     else:
         return default
+
+
+def get_conf_path(default = "conf.ini"):
+    return os.environ["KSU_CONF_FILE"] if "KSU_CONF_FILE" in os.environ else default

--- a/kensu/utils/helpers.py
+++ b/kensu/utils/helpers.py
@@ -207,12 +207,17 @@ def extract_short_json_schema(result, result_ds):
 def extract_config_property(key, default, arg=None, kw=None, conf=None, tpe=None):
     """
     Looks for a property value following this precedence:
-      arg > kwargs > conf > env_var > default
+      env_var > arg > kwargs > conf > default
     The default value is used to determine the type of the conf value (it can be overridden by tpe).
     The environment variable will be looked up based on the pattern of `KSU_<upper-key>`.
     """
 
-    if arg is not None:
+    if os.environ.get("KSU_" + key.upper()) is not None:
+        env_var = os.environ.get(key)
+        if tpe is not None:
+            env_var = tpe(env_var)
+        return env_var
+    elif arg is not None:
         return arg
     elif key in kw and kw[key] is not None:
         return kw[key]
@@ -227,11 +232,6 @@ def extract_config_property(key, default, arg=None, kw=None, conf=None, tpe=None
         elif tpe is not None:
             r = tpe(r)
         return r
-    elif os.environ.get("KSU_" + key.upper()) is not None:
-        env_var = os.environ.get(key)
-        if tpe is not None:
-            env_var = tpe(env_var)
-        return env_var
     else:
         return default
 

--- a/kensu/utils/kensu.py
+++ b/kensu/utils/kensu.py
@@ -1,7 +1,8 @@
 import datetime
 import getpass
-import os
 import jwt
+import os
+
 
 from kensu.client import *
 from kensu.utils.dsl.extractors.external_lineage_dtos import KensuDatasourceAndSchema
@@ -117,7 +118,7 @@ class Kensu(object):
         execution_timestamp = get_property("execution_timestamp", None, tpe=int)
         logical_data_source_naming_strategy = get_property("logical_data_source_naming_strategy", None)
 
-        report_in_mem = get_property("report_in_mem", False)
+        report_in_mem = get_property("report_in_mem", False)  # TODO dismiss, set default
 
         #  Required to be always on. Config dropped since 2.0.0
         mapping = True

--- a/kensu/utils/kensu.py
+++ b/kensu/utils/kensu.py
@@ -8,7 +8,7 @@ from kensu.utils.dsl.extractors.external_lineage_dtos import KensuDatasourceAndS
 from kensu.utils.dsl import mapping_strategies
 from kensu.utils.dsl.extractors import Extractors
 from kensu.utils.dsl.lineage_builder import LineageBuilder
-from kensu.utils.helpers import to_hash_key, extract_config_property
+from kensu.utils.helpers import extract_config_property, get_conf_path, to_hash_key
 from kensu.utils.injection import Injection
 from kensu.utils.reporters import *
 from kensu.utils.rule_engine import create_kensu_nrows_consistency
@@ -60,17 +60,13 @@ class Kensu(object):
         return code_version
 
     @staticmethod
-    def get_conf_path(self, default = "conf.ini"):
-        return os.environ["CONF_FILE"] if "CONF_FILE" in os.environ else default
-
-    @staticmethod
     def build_conf():
         """
         Returns configparser.ConfigParser
         """
         from configparser import ConfigParser, ExtendedInterpolation
         config = ConfigParser(interpolation=ExtendedInterpolation())
-        conf_path = Kensu.get_conf_path("conf.ini")
+        conf_path = get_conf_path("conf.ini")
         try:
             config.read(conf_path)
         except:
@@ -119,7 +115,7 @@ class Kensu(object):
         project_name = get_property("project_name", [])
         environment = get_property("environment", None)
         execution_timestamp = get_property("execution_timestamp", None, tpe=int)
-        logical_naming = get_property("logical_naming", None)
+        logical_data_source_naming_strategy = get_property("logical_data_source_naming_strategy", None)
 
         report_in_mem = get_property("report_in_mem", False)
 
@@ -178,7 +174,7 @@ class Kensu(object):
         injection.set_do_report(do_report, offline_file_name=offline_file_name, report_to_file=report_to_file)
         injection.set_kensu_api(self.kensu_api)
 
-        self.logical_naming = logical_naming
+        self.logical_naming = logical_data_source_naming_strategy
         self.mapping = mapping
         self.report_in_mem = report_in_mem
         self.compute_stats = compute_stats

--- a/kensu/utils/kensu.py
+++ b/kensu/utils/kensu.py
@@ -118,7 +118,7 @@ class Kensu(object):
         execution_timestamp = get_property("execution_timestamp", None, tpe=int)
         logical_data_source_naming_strategy = get_property("logical_data_source_naming_strategy", None)
 
-        report_in_mem = get_property("report_in_mem", False)  # TODO dismiss, set default
+        report_in_mem = False
 
         #  Required to be always on. Config dropped since 2.0.0
         mapping = True

--- a/kensu/utils/kensu.py
+++ b/kensu/utils/kensu.py
@@ -73,7 +73,7 @@ class Kensu(object):
             logging.warning(f"Cannot load config from file `%s`" % (conf_path))
         return config
 
-    def __init__(self, ingestion_url=None, ingestion_token=None, process_name=None,
+    def __init__(self, kensu_ingestion_url=None, kensu_ingestion_token=None, process_name=None,
                  user_name=None, code_location=None, do_report=None, report_to_file=None, offline_file_name=None,
                  compute_stats=True, config=None, **kwargs):
         """
@@ -88,8 +88,8 @@ class Kensu(object):
         def get_property(key, default, arg=None, kw=kwargs, conf=kensu_conf, tpe=None):
             return extract_config_property(key, default, arg, kw, conf, tpe)
 
-        kensu_host = get_property("ingestion_url", None, ingestion_url)
-        kensu_auth_token = get_property("ingestion_token", None, ingestion_token)
+        kensu_host = get_property("kensu_ingestion_url", None, kensu_ingestion_url)
+        kensu_auth_token = get_property("kensu_ingestion_token", None, kensu_ingestion_token)
 
         self.extractors = Extractors()
 
@@ -140,7 +140,7 @@ class Kensu(object):
 
         compute_stats = get_property("compute_stats", True, compute_stats)
         compute_input_stats = get_property("compute_input_stats", True)
-        compute_delta = get_property("compute_delta", False)
+        compute_delta = get_property("compute_delta_stats", False)
         if compute_delta and not compute_input_stats:
             logging.warning("delta nrows stats (compute_delta=True) will not work without setting compute_input_stats=True")
         raise_on_check_failure = get_property("raise_on_check_failure", False)
@@ -151,9 +151,9 @@ class Kensu(object):
         self.api_url = kensu_host
         self.report_to_file = report_to_file
 
-        sdk_pat = get_property("api_token", None)
-        sdk_url = get_property("api_url", None)
-        sdk_verify_ssl = get_property("api_verify_ssl", True)
+        sdk_pat = get_property("kensu_api_token", None)
+        sdk_url = get_property("kensu_api_url", None)
+        sdk_verify_ssl = get_property("kensu_api_verify_ssl", True)
         if sdk_pat is None:
             self.sdk = sdk.DoNothingSDK()
         else:

--- a/kensu/utils/kensu_provider.py
+++ b/kensu/utils/kensu_provider.py
@@ -16,7 +16,9 @@ class KensuProvider(object):
 
     # FIXME: probably we don't need get_explicit_code_version_fn & get_code_version_fn anymore. but keeping it for backwards-compat for now...
     @staticmethod
-    def initKensu(api_url=None, auth_token=None, process_name=None, user_name=None, code_location=None, get_code_version_fn=None, get_explicit_code_version_fn=None, init_context=True, do_report=None, report_to_file=None, offline_file_name=None, reporter=None, **kwargs):
+    def initKensu(ingestion_url=None, ingestion_token=None, process_name=None, user_name=None, code_location=None,
+                  get_code_version_fn=None, get_explicit_code_version_fn=None, do_report=None,
+                  report_to_file=None, offline_file_name=None, reporter=None, **kwargs):
         allow_reinit = kwargs["allow_reinit"] if "allow_reinit" in kwargs else False
         ksu_provided_inst = KensuProvider().instance()
         if ksu_provided_inst is not None and allow_reinit:
@@ -25,33 +27,36 @@ class KensuProvider(object):
         if ksu_provided_inst is None or allow_reinit:
             from kensu.utils.kensu import Kensu
             pandas_support = kwargs.get("pandas_support", True)
+
             sklearn_support = kwargs.get("sklearn_support")
-            bigquery_support = kwargs.get("bigquery_support")
+
             tensorflow_support = kwargs.get("tensorflow_support")
+
+            bigquery_support = kwargs.get("bigquery_support")
             bigquery_headers = kwargs.get("bigquery_headers")
 
-            project_names = kwargs.get("project_names")
+            project_name = kwargs.get("project_name")
             environment = kwargs.get("environment")
-            timestamp = kwargs.get("timestamp")
+            execution_timestamp = kwargs.get("execution_timestamp")
             logical_naming = kwargs.get("logical_naming")
-            mapping = kwargs["mapping"] if "mapping" in kwargs else True
             report_in_mem = kwargs.get("report_in_mem")
             get_code_version = kwargs.get("get_code_version")
             stats = kwargs.get("compute_stats")
             input_stats = kwargs.get("input_stats")
-            sql_util_url = kwargs.get("sql_util_url")
             compute_delta = kwargs.get("compute_delta")
-            sdk_verify_ssl = kwargs.get("sdk_verify_ssl")
+            kensu_sql_parser_url = kwargs.get("kensu_sql_parser_url")
+            api_verify_ssl = kwargs.get("api_verify_ssl")
 
-            _kensu = Kensu(api_url=api_url, auth_token=auth_token, process_name=process_name, user_name=user_name,
-                      code_location=code_location, init_context=init_context, do_report=do_report, pandas_support = pandas_support,
-                      sklearn_support = sklearn_support, bigquery_support = bigquery_support, tensorflow_support = tensorflow_support, 
-                      project_names=project_names,environment=environment,timestamp=timestamp,logical_naming=logical_naming,mapping=mapping, report_in_mem = report_in_mem,
-                      report_to_file=report_to_file, offline_file_name=offline_file_name, reporter=reporter,
-                      get_code_version=get_explicit_code_version_fn or get_code_version or get_code_version_fn,
-                      compute_stats=stats,input_stats=input_stats, bigquery_headers = bigquery_headers, sql_util_url= sql_util_url,
-                      compute_delta=compute_delta,
-                      sdk_verify_ssl=sdk_verify_ssl)
+            _kensu = Kensu(ingestion_url=ingestion_url, ingestion_token=ingestion_token, process_name=process_name,
+                           user_name=user_name, code_location=code_location, api_verify_ssl=api_verify_ssl,
+                           do_report=do_report, pandas_support=pandas_support, sklearn_support=sklearn_support,
+                           bigquery_support=bigquery_support, tensorflow_support=tensorflow_support,
+                           project_name=project_name, environment=environment, execution_timestamp=execution_timestamp,
+                           logical_naming=logical_naming, report_in_mem=report_in_mem,
+                           report_to_file=report_to_file, offline_file_name=offline_file_name, reporter=reporter,
+                           get_code_version=get_explicit_code_version_fn or get_code_version or get_code_version_fn,
+                           compute_stats=stats, input_stats=input_stats, bigquery_headers=bigquery_headers,
+                           kensu_sql_parser_url=kensu_sql_parser_url, compute_delta=compute_delta)
 
             KensuProvider().setKensu(_kensu)
             return _kensu

--- a/kensu/utils/kensu_provider.py
+++ b/kensu/utils/kensu_provider.py
@@ -16,7 +16,7 @@ class KensuProvider(object):
 
     # FIXME: probably we don't need get_explicit_code_version_fn & get_code_version_fn anymore. but keeping it for backwards-compat for now...
     @staticmethod
-    def initKensu(ingestion_url=None, ingestion_token=None, process_name=None, user_name=None, code_location=None,
+    def initKensu(kensu_ingestion_url=None, kensu_ingestion_token=None, process_name=None, user_name=None, code_location=None,
                   get_code_version_fn=None, get_explicit_code_version_fn=None, do_report=None,
                   report_to_file=None, offline_file_name=None, reporter=None, **kwargs):
         allow_reinit = kwargs["allow_reinit"] if "allow_reinit" in kwargs else False
@@ -42,12 +42,12 @@ class KensuProvider(object):
             report_in_mem = kwargs.get("report_in_mem")
             get_code_version = kwargs.get("get_code_version")
             stats = kwargs.get("compute_stats")
-            input_stats = kwargs.get("input_stats")
-            compute_delta = kwargs.get("compute_delta")
+            input_stats = kwargs.get("compute_input_stats")
+            compute_delta = kwargs.get("compute_delta_stats")
             kensu_sql_parser_url = kwargs.get("kensu_sql_parser_url")
-            api_verify_ssl = kwargs.get("api_verify_ssl")
+            api_verify_ssl = kwargs.get("kensu_api_verify_ssl")
 
-            _kensu = Kensu(ingestion_url=ingestion_url, ingestion_token=ingestion_token, process_name=process_name,
+            _kensu = Kensu(kensu_ingestion_url=kensu_ingestion_url, kensu_ingestion_token=kensu_ingestion_token, process_name=process_name,
                            user_name=user_name, code_location=code_location, api_verify_ssl=api_verify_ssl,
                            do_report=do_report, pandas_support=pandas_support, sklearn_support=sklearn_support,
                            bigquery_support=bigquery_support, tensorflow_support=tensorflow_support,
@@ -55,8 +55,8 @@ class KensuProvider(object):
                            logical_data_source_naming_strategy=logical_data_source_naming_strategy, report_in_mem=report_in_mem,
                            report_to_file=report_to_file, offline_file_name=offline_file_name, reporter=reporter,
                            get_code_version=get_explicit_code_version_fn or get_code_version or get_code_version_fn,
-                           compute_stats=stats, input_stats=input_stats, bigquery_headers=bigquery_headers,
-                           kensu_sql_parser_url=kensu_sql_parser_url, compute_delta=compute_delta)
+                           compute_stats=stats, compute_input_stats=input_stats, bigquery_headers=bigquery_headers,
+                           kensu_sql_parser_url=kensu_sql_parser_url, compute_delta_stats=compute_delta)
 
             KensuProvider().setKensu(_kensu)
             return _kensu

--- a/kensu/utils/kensu_provider.py
+++ b/kensu/utils/kensu_provider.py
@@ -39,7 +39,6 @@ class KensuProvider(object):
             environment = kwargs.get("environment")
             execution_timestamp = kwargs.get("execution_timestamp")
             logical_data_source_naming_strategy = kwargs.get("logical_data_source_naming_strategy")
-            report_in_mem = kwargs.get("report_in_mem")
             get_code_version = kwargs.get("get_code_version")
             stats = kwargs.get("compute_stats")
             input_stats = kwargs.get("compute_input_stats")
@@ -48,11 +47,11 @@ class KensuProvider(object):
             api_verify_ssl = kwargs.get("kensu_api_verify_ssl")
 
             _kensu = Kensu(kensu_ingestion_url=kensu_ingestion_url, kensu_ingestion_token=kensu_ingestion_token, process_name=process_name,
-                           user_name=user_name, code_location=code_location, api_verify_ssl=api_verify_ssl,
+                           user_name=user_name, code_location=code_location, kensu_api_verify_ssl=api_verify_ssl,
                            do_report=do_report, pandas_support=pandas_support, sklearn_support=sklearn_support,
                            bigquery_support=bigquery_support, tensorflow_support=tensorflow_support,
                            project_name=project_name, environment=environment, execution_timestamp=execution_timestamp,
-                           logical_data_source_naming_strategy=logical_data_source_naming_strategy, report_in_mem=report_in_mem,
+                           logical_data_source_naming_strategy=logical_data_source_naming_strategy,
                            report_to_file=report_to_file, offline_file_name=offline_file_name, reporter=reporter,
                            get_code_version=get_explicit_code_version_fn or get_code_version or get_code_version_fn,
                            compute_stats=stats, compute_input_stats=input_stats, bigquery_headers=bigquery_headers,

--- a/kensu/utils/kensu_provider.py
+++ b/kensu/utils/kensu_provider.py
@@ -38,7 +38,7 @@ class KensuProvider(object):
             project_name = kwargs.get("project_name")
             environment = kwargs.get("environment")
             execution_timestamp = kwargs.get("execution_timestamp")
-            logical_naming = kwargs.get("logical_naming")
+            logical_data_source_naming_strategy = kwargs.get("logical_data_source_naming_strategy")
             report_in_mem = kwargs.get("report_in_mem")
             get_code_version = kwargs.get("get_code_version")
             stats = kwargs.get("compute_stats")
@@ -52,7 +52,7 @@ class KensuProvider(object):
                            do_report=do_report, pandas_support=pandas_support, sklearn_support=sklearn_support,
                            bigquery_support=bigquery_support, tensorflow_support=tensorflow_support,
                            project_name=project_name, environment=environment, execution_timestamp=execution_timestamp,
-                           logical_naming=logical_naming, report_in_mem=report_in_mem,
+                           logical_data_source_naming_strategy=logical_data_source_naming_strategy, report_in_mem=report_in_mem,
                            report_to_file=report_to_file, offline_file_name=offline_file_name, reporter=reporter,
                            get_code_version=get_explicit_code_version_fn or get_code_version or get_code_version_fn,
                            compute_stats=stats, input_stats=input_stats, bigquery_headers=bigquery_headers,

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ NAME = "kensu"
 BUILD_FLAVOR = os.environ["BUILD_FLAVOR"] if "BUILD_FLAVOR" in os.environ else ""
 BUILD_NUMBER = os.environ["BUILD_NUMBER"] if "BUILD_NUMBER" in os.environ else ""
 # https://semver.org/
-VERSION = "2.0.0-" + BUILD_FLAVOR + BUILD_NUMBER
+VERSION = "2.0.0" + BUILD_FLAVOR + BUILD_NUMBER
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ NAME = "kensu"
 
 BUILD_FLAVOR = os.environ["BUILD_FLAVOR"] if "BUILD_FLAVOR" in os.environ else ""
 BUILD_NUMBER = os.environ["BUILD_NUMBER"] if "BUILD_NUMBER" in os.environ else ""
-VERSION = "1.9.3.3" + BUILD_FLAVOR + BUILD_NUMBER
+# https://semver.org/
+VERSION = "2.0.0-" + BUILD_FLAVOR + BUILD_NUMBER
 
 
 

--- a/tests/unit/conf.ini
+++ b/tests/unit/conf.ini
@@ -1,22 +1,20 @@
 [kensu]
 
-;api_url
-;api_token
-;project_names
+;kensu_ingestion_url
+;kensu_ingestion_token
+;project_name
 ;environment
 ;process_name
 ;user_name
 ;code_location
-;logical_naming
-;mapping
+;logical_data_source_naming_strategy
 ;do_report
-;report_in_mem
 ;report_to_file
 ;offline_file_name
 ;pandas_support
 ;sklearn_support
 ;bigquery_support
 ;tensorflow_support
-sql_util_url=http://127.0.0.1:5000
+kensu_sql_parser_url=http://127.0.0.1:5000
 
 [kensu.reporter]

--- a/tests/unit/test_aws.py
+++ b/tests/unit/test_aws.py
@@ -9,8 +9,8 @@ if __name__ == '__main__':
     api_url = os.environ.get('KSU_API_URL') or ''
     auth_token = os.environ.get('KSU_API_TOKEN') or ''
     kensu = KensuProvider().initKensu(init_context=True,
-                                      ingestion_url=api_url,
-                                      ingestion_token=auth_token,
+                                      kensu_ingestion_url=api_url,
+                                      kensu_ingestion_token=auth_token,
                                       report_to_file=offline,
                                       project_names=['aws s3'],
                                       offline_file_name='kensu-offline-to-aws-s3-test.jsonl',

--- a/tests/unit/test_aws.py
+++ b/tests/unit/test_aws.py
@@ -9,8 +9,8 @@ if __name__ == '__main__':
     api_url = os.environ.get('KSU_API_URL') or ''
     auth_token = os.environ.get('KSU_API_TOKEN') or ''
     kensu = KensuProvider().initKensu(init_context=True,
-                                      api_url=api_url,
-                                      auth_token=auth_token,
+                                      ingestion_url=api_url,
+                                      ingestion_token=auth_token,
                                       report_to_file=offline,
                                       project_names=['aws s3'],
                                       offline_file_name='kensu-offline-to-aws-s3-test.jsonl',

--- a/tests/unit/test_aws.py
+++ b/tests/unit/test_aws.py
@@ -6,8 +6,8 @@ if __name__ == '__main__':
 
     ## kensu setup
     offline = True
-    api_url = os.environ.get('KSU_API_URL') or ''
-    auth_token = os.environ.get('KSU_API_TOKEN') or ''
+    api_url = os.environ.get('KSU_KENSU_INGESTION_URL') or ''
+    auth_token = os.environ.get('KSU_KENSU_INGESTION_TOKEN') or ''
     kensu = KensuProvider().initKensu(init_context=True,
                                       kensu_ingestion_url=api_url,
                                       kensu_ingestion_token=auth_token,

--- a/tests/unit/test_guid.py
+++ b/tests/unit/test_guid.py
@@ -29,7 +29,7 @@ class TestRawEvents(unittest.TestCase):
         , "MODEL_METRICS": "ModelMetrics"
     }
 
-    kensu = Kensu(api_url = "http://example.com", init_context = False, reporter = "DoNothingReporter")
+    kensu = Kensu(ingestion_url="http://example.com", init_context = False, reporter ="DoNothingReporter")
 
     def setUp(self):
         self.data = {}

--- a/tests/unit/test_guid.py
+++ b/tests/unit/test_guid.py
@@ -29,7 +29,7 @@ class TestRawEvents(unittest.TestCase):
         , "MODEL_METRICS": "ModelMetrics"
     }
 
-    kensu = Kensu(ingestion_url="http://example.com", init_context = False, reporter ="DoNothingReporter")
+    kensu = Kensu(kensu_ingestion_url="http://example.com", init_context = False, reporter ="DoNothingReporter")
 
     def setUp(self):
         self.data = {}

--- a/tests/unit/test_pandas.py
+++ b/tests/unit/test_pandas.py
@@ -16,7 +16,7 @@ logging.basicConfig(stream=sys.stdout, level=logging.INFO, format=log_format)
 
 class TestPandas(unittest.TestCase):
     token = ""
-    kensu = KensuProvider().initKensu(api_url="", auth_token=token, init_context=True, reporter="DoNothingReporter")
+    kensu = KensuProvider().initKensu(ingestion_url="", ingestion_token=token, init_context=True, reporter="DoNothingReporter")
 
     # FIXME... dunno ... that sounds rather nasty
     # def _constructor(self):

--- a/tests/unit/test_pandas.py
+++ b/tests/unit/test_pandas.py
@@ -16,7 +16,7 @@ logging.basicConfig(stream=sys.stdout, level=logging.INFO, format=log_format)
 
 class TestPandas(unittest.TestCase):
     token = ""
-    kensu = KensuProvider().initKensu(ingestion_url="", ingestion_token=token, init_context=True, reporter="DoNothingReporter")
+    kensu = KensuProvider().initKensu(kensu_ingestion_url="", kensu_ingestion_token=token, init_context=True, reporter="DoNothingReporter")
 
     # FIXME... dunno ... that sounds rather nasty
     # def _constructor(self):

--- a/tests/unit/testing_helpers.py
+++ b/tests/unit/testing_helpers.py
@@ -20,8 +20,8 @@ def setup_kensu_tracker(
         **kwargs
 ):
     offline = True
-    api_url = os.environ.get('KSU_API_URL') or ''
-    auth_token = os.environ.get('KSU_API_TOKEN') or ''
+    api_url = os.environ.get('KSU_KENSU_INGESTION_URL') or ''
+    auth_token = os.environ.get('KSU_KENSU_INGESTION_TOKEN') or ''
     if test_cls:
         test_name = test_cls.__class__.__name__
         if out_file is None:

--- a/tests/unit/testing_helpers.py
+++ b/tests/unit/testing_helpers.py
@@ -35,8 +35,8 @@ def setup_kensu_tracker(
     KensuProvider().initKensu(
         init_context=True,
         allow_reinit=True,
-        api_url=api_url,
-        auth_token=auth_token,
+        ingestion_url=api_url,
+        ingestion_token=auth_token,
         report_to_file=offline,
         project_names=project_names,
         offline_file_name=out_file,

--- a/tests/unit/testing_helpers.py
+++ b/tests/unit/testing_helpers.py
@@ -35,8 +35,8 @@ def setup_kensu_tracker(
     KensuProvider().initKensu(
         init_context=True,
         allow_reinit=True,
-        ingestion_url=api_url,
-        ingestion_token=auth_token,
+        kensu_ingestion_url=api_url,
+        kensu_ingestion_token=auth_token,
         report_to_file=offline,
         project_names=project_names,
         offline_file_name=out_file,


### PR DESCRIPTION
This is a breaking change (one of two PRs) and thus targets the `release/2.0.0` branch, which will be ready to merge to `main` after additional testing and additional cleanup on Kensu brand naming.