### PR TITLE
Add Timestream-query and fix timestream-write schema

### DIFF
--- a/common-requirements.txt
+++ b/common-requirements.txt
@@ -21,3 +21,5 @@ pyjwt
 
 # config
 configparser
+
+sqllineage >= 1.3.7

--- a/kensu/boto3/__init__.py
+++ b/kensu/boto3/__init__.py
@@ -100,8 +100,14 @@ def kensu_put(event_params, event_ctx, **kwargs):
 def fmt_timestream_uri(db, table):
     return f"aws::TimeStream://{db}.{table}"
 
+
 def fmt_timestream_name(db, table):
     return f"TimeStream://{db}.{table}"
+
+
+def fmt_timestream_lds_name(db, table):
+    return fmt_timestream_name(db, table)
+
 
 def fmt_timesteam_lds_names(db, table):
     # FIXME: for now DS name and LDS name (and LDS location) must match (need to update write_reconds otherwise)

--- a/kensu/boto3/__init__.py
+++ b/kensu/boto3/__init__.py
@@ -116,7 +116,7 @@ def fmt_timesteam_lds_names(db, table):
             ]
 
 def kensu_timestream_query(event_params):
-    logging.warning('KENSU: handler of timestream_query.query...')
+    logging.info('KENSU: handler of timestream_query.query...')
     # if true, we'll report all columns found in the table, doesn't matter what columns were actually referred
     # FIXME: do we care about exact columns which were referred?
     ALWAYS_REPORT_ALL_COLUMNS = True

--- a/kensu/boto3/__init__.py
+++ b/kensu/boto3/__init__.py
@@ -1,3 +1,5 @@
+import logging
+
 import boto3
 from boto3 import *
 
@@ -81,6 +83,133 @@ def kensu_put(event_params, event_ctx, **kwargs):
             kensu.add_dependencies_mapping(short_result_sc.to_guid(),str(col),input_schema_pk,str(col),'s3_put')
         kensu.report_with_mapping()
 
+
+def fmt_timestream_uri(db, table):
+    return f"aws::TimeStream://{db}.{table}"
+
+def fmt_timestream_name(db, table):
+    return f"TimeStream://{db}.{table}"
+
+
+def fmt_timesteam_lds_names(db, table):
+    return ['logical::' + fmt_timestream_name(db, table),
+            'logicalLocation::' + fmt_timestream_uri(db, table),
+            ]
+
+def kensu_timestream_query(event_params):
+    logging.warning('KENSU: handler of timestream_query.query...')
+    # if true, we'll report all columns found in the table, doesn't matter what columns were actually referred
+    # FIXME: do we care about exact columns which were referred?
+    ALWAYS_REPORT_ALL_COLUMNS = True
+    from pprint import pprint
+
+    sql = event_params['QueryString']
+    # ignore kensu agent issued queries
+    if 'DESCRIBE ' in sql:
+        return
+
+    # FIXME: pass custom config if any - context['client_config'] / context['client_region']
+    client = boto3.client('timestream-query')
+    aws_lineage = client.prepare_query(
+        QueryString=sql,
+        ValidateOnly=True  # do not store the query in the DB
+    )
+    # FIXME: also maybe need to check the query type (is it SELECT, INSERT etc?)
+
+    # P.S. "Aliased" property is "lying" in case we're querying a subquery, e.g.
+    # `select * from (select truck_id as truck_id_renamed from tbl)` will say Aliased=False,
+    # while in fact the column was renamed and we don't know it's original name
+    # so we need to verify existence of columns
+    resolved_db_tables = set([
+        (c['DatabaseName'], c['TableName'])
+        for c in aws_lineage.get('Columns', [])
+        if c.get('DatabaseName') and c.get('TableName')
+    ])
+    # add tables from sqlineage which might have been unresolved by `client.prepare_query`
+    try:
+        from sqllineage.runner import LineageRunner
+        lin_result = LineageRunner(sql, verbose=True)
+        maybe_source_tables = [
+            (t.schema.raw_name, t.raw_name)
+            for t in lin_result.source_tables
+            if t.schema and not (t.schema.raw_name, t.raw_name) in resolved_db_tables]
+        # sqllineage knows nothing about actual database, so check if such tables exist
+        for (db, table) in maybe_source_tables:
+            exists = True
+            try:
+                client.query(QueryString=f'DESCRIBE "{db}"."{table}"')
+            except:
+                exists = False
+            if exists:
+                resolved_db_tables.add((db, table))
+
+            # col_lin = lin_result.get_column_lineage(exclude_subquery=False)
+    except:
+        logging.info(f"Exception while extracting sqllineage for timesteam-query")
+
+
+    # FIXME: in some cases even the table name is not available in prepare_query result, use sqllineage as fallback
+    # e.g. when refering to a column of certain table only inside expression
+    full_table_schemas = {
+        (db, table): {row['Data'][0]['ScalarValue']: row['Data'][1]['ScalarValue']
+                       for row in client.query(QueryString=f'DESCRIBE "{db}"."{table}"').get('Rows', [])}
+        for (db, table) in resolved_db_tables
+    }
+    # not renamed columns, if any
+    unchecked_known_input_columns = [
+        (c['Name'], c['DatabaseName'], c['TableName'])
+        # {'column_name': c['Name'],
+        #  'db': c['DatabaseName'],
+        #  'table': c['TableName']}
+        for c in aws_lineage.get('Columns', [])
+        if c.get('DatabaseName') and c.get('TableName') and c.get('Name')
+    ]
+    validated_discovered_input_columns = [
+        (db, table, col_name, full_table_schemas.get((db, table), {}).get(col_name))
+        for (col_name, db, table) in unchecked_known_input_columns
+        if full_table_schemas.get((db, table), {}).get(col_name)
+    ]
+    from collections import defaultdict
+    validated_input_columns = defaultdict(lambda: {})
+    for (db, table, col_name, data_type) in validated_discovered_input_columns:
+        validated_input_columns[(db, table)][col_name] = data_type
+
+    # FIXME: get input columns from sqllineage too...
+    # for each discovered input table, if we didn't find any input columns, assume that all columns were accessed
+    for (db, table) in resolved_db_tables:
+        if not validated_input_columns.get((db, table)) or ALWAYS_REPORT_ALL_COLUMNS:
+            logging.warning(f"Kensu was unable to find exact input columns for timestream query table '{db}'.'{table}', using all columns...")
+            validated_input_columns[(db, table)] = full_table_schemas.get((db, table), {})
+
+    #print("Kensu Timestream-query:")
+    #pprint(resolved_db_tables)
+    #pprint(full_table_schemas)
+    #pprint(validated_discovered_input_columns)
+    #print("final:")
+    #pprint(validated_input_columns)
+    # report read operation to Kensu
+    from kensu.utils.dsl.extractors.external_lineage_dtos import KensuDatasourceAndSchema
+    ksu = KensuProvider().instance()
+    for ((db, table), schema_dict) in validated_input_columns.items():
+        ds_name = fmt_timestream_name(db, table)
+        ds = KensuDatasourceAndSchema.for_path_with_opt_schema(
+            ksu=ksu,
+            ds_path=fmt_timestream_uri(db, table),
+            format="TimeStream table",
+            categories=fmt_timesteam_lds_names(db,table),
+            maybe_schema=schema_dict.items(),
+            ds_name=ds_name,
+        )
+        if ksu.degraded_mode:
+            ds.ksu_ds._report()
+            ds.ksu_schema._report()
+            ksu.real_schema_df[ds.ksu_schema.to_guid()] = None  # is this one needed?
+            ksu.register_input_degraded_mode(ds.ksu_schema)
+        else:
+            logging.warning("Timestream-query.query() kensu tracking is supported only in degraded_mode")
+
+
+
 def kensu_write_records(event_params):
     database = event_params['DatabaseName']
     table = event_params['TableName']
@@ -88,12 +217,12 @@ def kensu_write_records(event_params):
 
     kensu = KensuProvider().instance()
     # Creation of the output datasource (stored in S3)
-    location = 'aws::TimeStream::' + database + '.' + table
-    name = database + '.' + table
+    location = fmt_timestream_uri(database, table)
+    name = fmt_timestream_name(database, table)
 
     result_pk = DataSourcePK(location=location,
                              physical_location_ref=kensu.default_physical_location_ref)
-    result_ds = DataSource(name=name, categories=['logical::'+name],format='TimeStream',
+    result_ds = DataSource(name=name, categories=fmt_timesteam_lds_names(database, table),format='TimeStream',
                            pk=result_pk)._report()
 
     from kensu.utils.helpers import extract_short_json_schema
@@ -169,6 +298,8 @@ def kensu_tracker(*class_attributes, **kwargs):
         kensu_put(event_params=event_params, event_ctx=event_ctx, **kwargs)
     if event_name == 'provide-client-params.timestream-write.WriteRecords' and event_params:
         kensu_write_records(event_params)
+    if event_name == 'provide-client-params.timestream-query.Query' and event_params:
+        kensu_timestream_query(event_params)
 
 #boto3._get_default_session().events.register('creating-resource-class.s3.ServiceResource',kensu_tracker)
 #boto3._get_default_session().events.register('before-send.s3.PutObject', kensu_tracker)
@@ -180,8 +311,7 @@ boto3._get_default_session().events.register('provide-client-params.s3.PutObject
 #event_system.register("*",kensu_tracker)
 #event_system.register('creating-resource-class.s3.*', prt)
 
+#boto3._get_default_session().events.register("*",kensu_tracker)
 
 boto3._get_default_session().events.register('provide-client-params.timestream-write.WriteRecords', kensu_tracker)
-
-
-#'provide-client-params.timestream-write.WriteRecords':
+boto3._get_default_session().events.register('provide-client-params.timestream-query.Query', kensu_tracker)

--- a/kensu/boto3/__init__.py
+++ b/kensu/boto3/__init__.py
@@ -93,7 +93,7 @@ def fmt_timestream_name(db, table):
 
 def fmt_timesteam_lds_names(db, table):
     return ['logical::' + fmt_timestream_name(db, table),
-            'logicalLocation::' + fmt_timestream_uri(db, table),
+            # 'logicalLocation::' + fmt_timestream_uri(db, table),
             ]
 
 def kensu_timestream_query(event_params):

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ NAME = "kensu"
 BUILD_FLAVOR = os.environ["BUILD_FLAVOR"] if "BUILD_FLAVOR" in os.environ else ""
 BUILD_NUMBER = os.environ["BUILD_NUMBER"] if "BUILD_NUMBER" in os.environ else ""
 # https://semver.org/
-VERSION = "2.2.0" + BUILD_FLAVOR + BUILD_NUMBER
+VERSION = "2.3.0" + BUILD_FLAVOR + BUILD_NUMBER
 
 
 


### PR DESCRIPTION
- [x] timestream-query: table names from `.client('timestream-query').prepare_query()`
- [x] timestream-query: table names from `sqllineage`
- [x] timestream-write: fix column name / schema extraction 
- [ ] timestream-write: MAYBE infer datatypes from python values / strings if not provided
- [ ] cleanup/refactor code
- [ ] maybe: add extra colums from `sqllineage` (not needed if using `ALWAYS_REPORT_ALL_COLUMNS = True`)