### PR TITLE
report process info as batch, clean timestamp management, made PL reporting configurable

### DIFF
--- a/.github/workflows/pypi-publish-on-release.yml
+++ b/.github/workflows/pypi-publish-on-release.yml
@@ -27,11 +27,6 @@ jobs:
         --wheel
         --outdir dist/
         .
-    - name: Publish distribution 📦 to Test PyPI
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
     - name: Publish distribution 📦 to PyPI
       if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@master

--- a/.github/workflows/testpypi-publish-on-pr.yml
+++ b/.github/workflows/testpypi-publish-on-pr.yml
@@ -27,6 +27,12 @@ jobs:
     - name: Test with pytest
       run: |
         CONF_FILE=tests/unit/conf.ini pytest --log-cli-level=INFO
+    - name: Install pypa/build
+      run: >-
+        python -m
+        pip install
+        build
+        --user
     - name: Build a binary wheel and a source tarball
       run: >-
         python -m

--- a/.github/workflows/testpypi-publish-on-pr.yml
+++ b/.github/workflows/testpypi-publish-on-pr.yml
@@ -27,3 +27,16 @@ jobs:
     - name: Test with pytest
       run: |
         CONF_FILE=tests/unit/conf.ini pytest --log-cli-level=INFO
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python -m
+        build
+        --sdist
+        --wheel
+        --outdir dist/
+        .
+    - name: Publish distribution 📦 to Test PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/

--- a/kensu/utils/kensu_provider.py
+++ b/kensu/utils/kensu_provider.py
@@ -27,6 +27,7 @@ class KensuProvider(object):
         if ksu_provided_inst is None or allow_reinit:
             from kensu.utils.kensu import Kensu
             pandas_support = kwargs.get("pandas_support", True)
+            numpy_support = kwargs.get("numpy_support", True)
 
             sklearn_support = kwargs.get("sklearn_support")
 
@@ -40,15 +41,18 @@ class KensuProvider(object):
             execution_timestamp = kwargs.get("execution_timestamp")
             logical_data_source_naming_strategy = kwargs.get("logical_data_source_naming_strategy")
             get_code_version = kwargs.get("get_code_version")
+            
             stats = kwargs.get("compute_stats")
             input_stats = kwargs.get("compute_input_stats")
             compute_delta = kwargs.get("compute_delta_stats")
             kensu_sql_parser_url = kwargs.get("kensu_sql_parser_url")
             api_verify_ssl = kwargs.get("kensu_api_verify_ssl")
+            
+            assume_default_physical_location_exists = kwargs.get("assume_default_physical_location_exists", False)
 
             _kensu = Kensu(kensu_ingestion_url=kensu_ingestion_url, kensu_ingestion_token=kensu_ingestion_token, process_name=process_name,
                            user_name=user_name, code_location=code_location, kensu_api_verify_ssl=api_verify_ssl,
-                           do_report=do_report, pandas_support=pandas_support, sklearn_support=sklearn_support,
+                           do_report=do_report, pandas_support=pandas_support, numpy_support=numpy_support, sklearn_support=sklearn_support,
                            bigquery_support=bigquery_support, tensorflow_support=tensorflow_support,
                            project_name=project_name, environment=environment, execution_timestamp=execution_timestamp,
                            logical_data_source_naming_strategy=logical_data_source_naming_strategy,
@@ -56,6 +60,7 @@ class KensuProvider(object):
                            get_code_version=get_explicit_code_version_fn or get_code_version or get_code_version_fn,
                            compute_stats=stats, compute_input_stats=input_stats, bigquery_headers=bigquery_headers,
                            kensu_sql_parser_url=kensu_sql_parser_url, compute_delta_stats=compute_delta,
+                           assume_default_physical_location_exists=assume_default_physical_location_exists,
                            report_process_info=report_process_info)
 
             KensuProvider().setKensu(_kensu)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ NAME = "kensu"
 BUILD_FLAVOR = os.environ["BUILD_FLAVOR"] if "BUILD_FLAVOR" in os.environ else ""
 BUILD_NUMBER = os.environ["BUILD_NUMBER"] if "BUILD_NUMBER" in os.environ else ""
 # https://semver.org/
-VERSION = "2.6.3" + BUILD_FLAVOR + BUILD_NUMBER
+VERSION = "2.6.4" + BUILD_FLAVOR + BUILD_NUMBER
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ NAME = "kensu"
 BUILD_FLAVOR = os.environ["BUILD_FLAVOR"] if "BUILD_FLAVOR" in os.environ else ""
 BUILD_NUMBER = os.environ["BUILD_NUMBER"] if "BUILD_NUMBER" in os.environ else ""
 # https://semver.org/
-VERSION = "2.6.2" + BUILD_FLAVOR + BUILD_NUMBER
+VERSION = "2.6.3" + BUILD_FLAVOR + BUILD_NUMBER
 
 
 


### PR DESCRIPTION
We have seen performance issues with the building of clients in Airflow, and the client often took several seconds to initiate.
After some analysis, several areas of improvement were detected:

- the process info composed of process, project, user, code base, code version, and process run sends each object 1by1 to the Kensu API
- the version seems to check git, which may not be needed when it is provided
- pandas support is enabled by default and takes some time to load
- the default physical location is always reported, which adds an unnecessary payload for all requests but the first one when the server is empty


Hence, this PR adds
- when building a client, the reporting of the process info is now in 1 batch
- the git check is skipped when it should
- pandas support is made optional, alongside numpy (`pandas_support` and `numpy_support`) -- Still True by default
- physical location reporting is made optional if we assume it is already in the backend using the configuration: `assume_default_physical_location_exists` to True