### PR TITLE
Fix test-pypi version override: add PR id & timestamp

### DIFF
--- a/.github/workflows/testpypi-publish-on-pr.yml
+++ b/.github/workflows/testpypi-publish-on-pr.yml
@@ -33,7 +33,13 @@ jobs:
         pip install
         build
         --user
+    - name: Store unix timestamp in BUILD_NUMBER env var
+      run: echo "BUILD_NUMBER=.dev$(date +%s)" >> $GITHUB_ENV
     - name: Build a binary wheel and a source tarball
+      # store PR number in BUILD_FLAVOR env var
+      # so we'll get version like 0.0.1.123.dev1694786623 where 123 is PR number
+      env:
+        BUILD_FLAVOR: .alpha${{ github.event.number }}
       run: >-
         python -m
         build


### PR DESCRIPTION
test-pypi doesn't allow to upload same version multiple times, thus up to now, subsequent pushes to a branch/PR were failing, if version wasn't bumped with each push.
Fixing it by changing test-pypi version to the following format:
```
major.minor.bugfix.alpha<prnum>.dev<timestamp>
```
e.g. https://test.pypi.org/project/kensu/2.6.10a167.dev1694790407/