### PR TITLE
TRI-297 add simple df.write wrapper for observe metrics

### DIFF
--- a/kensu/pyspark/spark_connector.py
+++ b/kensu/pyspark/spark_connector.py
@@ -281,7 +281,9 @@ def patch_kensu_df_helpers():
     ])) + [
         ['report_as_kensu_datasource', report_df_as_kensu_datasource()],
         ['report_as_kensu_jdbc_datasource', report_df_as_kensu_jdbc_datasource()],
-        ['report_as_kpi', report_df_as_kpi()]
+        ['report_as_kpi', report_df_as_kpi()],
+        ['write', kensuEfficientWriteProp],
+        ['kensuEfficientWrite', kensuEfficientWriteProp]
     ]
     for fn_name, wrapper_builder in fns_to_patch:
         try:
@@ -1008,6 +1010,21 @@ def addCustomObservationsToOutput(df,  # type: DataFrame
         "ksu_metrics_output_custom_gen{}".format(next_observation_num),
        *exprs
     )
+
+
+from pyspark.sql.dataframe import DataFrameWriter, DataFrame
+
+def kensuEfficientWrite(self) -> DataFrameWriter:
+    """Same as Spark DataFrame.write but adds efficient Kensu Observations"""
+    # FIXME: make compute_count_distinct=False parameterizable
+    # FIXME: implement remote conf -- need output path for that, so will need much more complex wrapper .parquet .csv etc
+    return DataFrameWriter(addOutputObservations(self, compute_count_distinct=False))
+
+
+@property
+def kensuEfficientWriteProp(self) -> DataFrameWriter:
+    """Same as Spark DataFrame.write but adds efficient Kensu Observations"""
+    return kensuEfficientWrite(self)
 
 
 def pyspark_datatype_to_jvm(jvm, pyspark_datatype):

--- a/kensu/pyspark/spark_connector.py
+++ b/kensu/pyspark/spark_connector.py
@@ -1027,7 +1027,6 @@ def make_kensu_efficient_write_fn(kensu_efficient_write_compute_count_distinct=F
 
     def kensu_efficient_write(self):
         """Same as Spark DataFrame.write but adds efficient Kensu Observations"""
-        # FIXME: make observe_compute_count_distinct=False parameterizable
         # FIXME: implement remote conf -- need output path for that, so will need much more complex wrapper .parquet .csv etc
         df = self
         try:


### PR DESCRIPTION
no need to add any extra code to Spark job, as we can override `df.write` function, I will make it configurable via conf option if we override the `df.write` or not.

optionally, one can call `df.kensu_efficient_write` to make this explicit.

----

*new config params:*

```python
init_kensu_spark(
    # patch_spark_data_frame=True, # existing, default True, if disabled kensu_efficient_write won't be available via DataFrame
    patch_spark_data_frame_write=True, # default True
    kensu_efficient_write_compute_count_distinct=False, # default False, if True .observe() will include count distinct
)
```

---

*To try out:*
```sh
pip install -i https://test.pypi.org/simple/ kensu==2.6.9a168.dev1695720686
```
and use [alpha spark-agent jar](https://public.usnek.com/n/repository/kensu-public/releases/kensu-spark-collector/alpha/kensu-spark-collector-1.3.0-alpha230926_1132_01-81c08f4_spark-3.4.0.jar)

*Tasks:*
- [x] implemented
- [x] test with new jar
- [ ] test with old jar if df.write patching not fails (otherwise we should use `patch_spark_data_frame_write=False` as default, or should we either case?)