### PR TITLE
efficient output metrics with remoteconf via spark observe

### DIFF
--- a/kensu/pyspark/KensuDataFrameWriter.py
+++ b/kensu/pyspark/KensuDataFrameWriter.py
@@ -1,0 +1,221 @@
+import sys
+from typing import cast, overload, Dict, Iterable, List, Optional, Tuple, TYPE_CHECKING, Union
+
+from py4j.java_gateway import JavaClass, JavaObject
+
+from pyspark import RDD, since
+from pyspark.sql.column import _to_seq, _to_java_column, Column
+from pyspark.sql.types import StructType
+from pyspark.sql import utils
+from pyspark.sql.utils import to_str
+
+from pyspark.sql.dataframe import DataFrameWriter
+
+if TYPE_CHECKING:
+    from pyspark.sql._typing import OptionalPrimitiveType, ColumnOrName
+    from pyspark.sql.session import SparkSession
+    from pyspark.sql.dataframe import DataFrame
+    from pyspark.sql.streaming import StreamingQuery
+
+__all__ = ["KensuDataFrameWriter"]
+
+PathOrPaths = Union[str, List[str]]
+TupleOrListOfString = Union[List[str], Tuple[str, ...]]
+
+
+# limitation: partition columns are not supported for LDS name for remote config
+
+class KensuDataFrameWriter:
+    """
+    Interface used to write a :class:`DataFrame` to external storage systems
+    (e.g. file systems, key-value stores, etc). Use :attr:`DataFrame.write`
+    to access this.
+
+    .. versionadded:: 1.4.0
+
+    .. versionchanged:: 3.4.0
+        Supports Spark Connect.
+    """
+
+    def __init__(self, df: "DataFrame"):
+        self._df = df
+        self._spark = df.sparkSession
+        self._df_writer = DataFrameWriter(df)  # mutable as we modify df at last moment before write
+        self._delayed_calls = []
+
+    # FIXME: implement  __getattr__(self, item) for unknown field names to defer to self._df_writer
+
+    def _delay_fn_call(self, fn):
+        self._delayed_calls.append(fn)
+        return self
+
+    def _update_df(self, new_df):
+        self._df = new_df
+        self._df_writer = DataFrameWriter(new_df)
+
+    def _call_deferred_fns(self):
+        # always returns same self, so it's fine
+        for fn in self._delayed_calls:
+            fn()
+
+
+    def mode(self, saveMode: Optional[str]) -> "KensuDataFrameWriter":
+        self._delay_fn_call(lambda: self._df_writer.mode(saveMode))
+        return self
+
+    def format(self, source: str) -> "KensuDataFrameWriter":
+        self._delay_fn_call(lambda: self._df_writer.format(source))
+        return self
+
+    def option(self, key: str, value: "OptionalPrimitiveType") -> "KensuDataFrameWriter":
+        self._delay_fn_call(lambda: self._df_writer.option(key, to_str(value)))
+        return self
+
+    def options(self, **options: "OptionalPrimitiveType") -> "KensuDataFrameWriter":
+        self._delay_fn_call(lambda: self._df_writer.options(**options))
+        return self
+
+    @overload
+    def partitionBy(self, *cols: str) -> "KensuDataFrameWriter":
+        ...
+
+    @overload
+    def partitionBy(self, *cols: List[str]) -> "KensuDataFrameWriter":
+        ...
+
+    def partitionBy(self, *cols: Union[str, List[str]]) -> "KensuDataFrameWriter":
+        self._delay_fn_call(lambda: self._df_writer.partitionBy(*cols))
+        return self
+
+    @overload
+    def bucketBy(self, numBuckets: int, col: str, *cols: str) -> "KensuDataFrameWriter":
+        ...
+
+    @overload
+    def bucketBy(self, numBuckets: int, col: TupleOrListOfString) -> "KensuDataFrameWriter":
+        ...
+
+    def bucketBy(
+        self, numBuckets: int, col: Union[str, TupleOrListOfString], *cols: Optional[str]
+    ) -> "KensuDataFrameWriter":
+        self._delay_fn_call(lambda: self._df_writer.bucketBy(numBuckets, col, *cols))
+        return self
+
+    @overload
+    def sortBy(self, col: str, *cols: str) -> "KensuDataFrameWriter":
+        ...
+
+    @overload
+    def sortBy(self, col: TupleOrListOfString) -> "KensuDataFrameWriter":
+        ...
+
+    def sortBy(
+        self, col: Union[str, TupleOrListOfString], *cols: Optional[str]
+    ) -> "KensuDataFrameWriter":
+        self._delay_fn_call(lambda: self._df_writer.sortBy(col, *cols))
+        return self
+
+    def _handle_simple_format_save(self,
+                                   path: Optional[str] = None,
+                                   format: Optional[str] = None
+                                   ):
+        # is format needed?
+        if path is not None:
+            # FIXME: impl observe
+            pass
+        df = self._df
+        try:
+            from kensu.pyspark.spark_connector import addOutputObservationsWithRemoteConf
+            kensu_efficient_write_compute_count_distinct = False  # FIXME: configure in a different way, if needed
+            import logging
+            logging.info("KENSU: DataFrameWriter for output path={} format={}, will be automatically updated with Kensu observations via .observe() using remote config if enabled".format(path, format))
+            df = addOutputObservationsWithRemoteConf(df,
+                                                     path=path,
+                                                     qualified_table_name=None,
+                                                     compute_count_distinct=kensu_efficient_write_compute_count_distinct)
+            logging.info("KENSU: DataFrameWriter for output path={} format={}, was updated with Kensu observations via .observe() using remote config if enabled".format(path, format))
+        except:
+            import traceback
+            import logging
+            logging.info(
+                "KENSU: unexpected issue when adding output observations, are you using old kensu Jar?: {}".format(
+                    traceback.format_exc()))
+        self._update_df(df)
+        self._call_deferred_fns()
+
+    def save(
+        self,
+        path: Optional[str] = None,
+        format: Optional[str] = None,
+        mode: Optional[str] = None,
+        partitionBy: Optional[Union[str, List[str]]] = None,
+        **options: "OptionalPrimitiveType",
+    ) -> None:
+        self._handle_simple_format_save(path, format)
+        return self._df_writer.save(path=path, format=format, mode=mode, partitionBy=partitionBy, **options)
+
+
+    def insertInto(self, tableName: str, overwrite: Optional[bool] = None) -> None:
+        # fixme: impl observe
+        return self._df_writer.insertInto(tableName, overwrite)
+
+    def saveAsTable(
+        self,
+        name: str,
+        format: Optional[str] = None,
+        mode: Optional[str] = None,
+        partitionBy: Optional[Union[str, List[str]]] = None,
+        **options: "OptionalPrimitiveType",
+    ) -> None:
+        # fixme: impl observe
+        return self._df_writer.saveAsTable(name=name, format=format, mode=mode, partitionBy=partitionBy, **options)
+
+    def json(
+        self,
+        path: str,
+        *args, **kwargs
+    ) -> None:
+        self._handle_simple_format_save(path, format="json")
+        return self._df_writer.json(path, *args, **kwargs)
+
+    def parquet(
+        self,
+        path: str,
+        mode: Optional[str] = None,
+        partitionBy: Optional[Union[str, List[str]]] = None,
+        compression: Optional[str] = None,
+    ) -> None:
+        self._handle_simple_format_save(path, format="parquet")
+        return self._df_writer.parquet(path=path, mode=mode, partitionBy=partitionBy, compression=compression)
+
+    def text(
+        self, path: str, compression: Optional[str] = None, lineSep: Optional[str] = None
+    ) -> None:
+        self._handle_simple_format_save(path, format="text")
+        return self._df_writer.text(path=path, compression=compression, lineSep=lineSep)
+
+    def csv(
+        self,
+        path: str,
+        *args, **kwargs
+    ) -> None:
+        self._handle_simple_format_save(path, format="csv")
+        return self._df_writer.csv(path, *args, **kwargs)
+
+    def orc(
+        self,
+        path: str,
+        *args, **kwargs
+    ) -> None:
+        self._handle_simple_format_save(path, format="orc")
+        return self._df_writer.orc(path, *args, **kwargs)
+
+    def jdbc(
+        self,
+        url: str,
+        table: str,
+        mode: Optional[str] = None,
+        properties: Optional[Dict[str, str]] = None,
+    ) -> None:
+        # FIXME: impl observe
+        return self._df_writer.jdbc(url=url, table=table, mode=mode, properties=properties)

--- a/kensu/pyspark/KensuDataFrameWriter.py
+++ b/kensu/pyspark/KensuDataFrameWriter.py
@@ -112,10 +112,11 @@ class KensuDataFrameWriter:
         self._delay_fn_call(lambda: self._df_writer.sortBy(col, *cols))
         return self
 
-    def _handle_simple_format_save(self,
-                                   path: Optional[str] = None,
-                                   format: Optional[str] = None
-                                   ):
+    def _handle_simple_save(self,
+                            path: Optional[str] = None,
+                            format: Optional[str] = None,
+                            table_name: Optional[str] = None
+                            ):
         if path is None:
             path = self._options.get("path", None)
         if path is not None:
@@ -124,18 +125,19 @@ class KensuDataFrameWriter:
                 from kensu.pyspark.spark_connector import addOutputObservationsWithRemoteConf
                 kensu_efficient_write_compute_count_distinct = False  # FIXME: configure in a different way, if needed
                 import logging
-                logging.info("KENSU: DataFrameWriter for output path={} format={}, will be automatically updated with Kensu observations via .observe() using remote config if enabled".format(path, format))
+                logging.info("KENSU: DataFrameWriter for output path={} table_name={} format={}, will be automatically updated with Kensu observations via .observe() using remote config if enabled".format(path, table_name, format))
                 df = addOutputObservationsWithRemoteConf(df,
                                                          path=path,
-                                                         table_name=None,
+                                                         table_name=table_name,
                                                          format=format,
                                                          compute_count_distinct=kensu_efficient_write_compute_count_distinct)
-                logging.info("KENSU: DataFrameWriter for output path={} format={}, was updated with Kensu observations via .observe() using remote config if enabled".format(path, format))
+                logging.info("KENSU: DataFrameWriter for output path={}  table_name={} format={}, was updated with Kensu observations via .observe() using remote config if enabled".format(path, table_name, format))
             except:
                 import traceback
                 import logging
                 logging.info(
-                    "KENSU: unexpected issue when adding output observations, are you using old kensu Jar?: {}".format(
+                    "KENSU: unexpected issue when adding output observations to output path={}  table_name={} format={}, are you using old kensu Jar?: {}".format(
+                        path, table_name, format,
                         traceback.format_exc()))
             self._update_df(df)
         self._call_deferred_fns()
@@ -148,11 +150,11 @@ class KensuDataFrameWriter:
         partitionBy: Optional[Union[str, List[str]]] = None,
         **options: "OptionalPrimitiveType",
     ) -> None:
-        self._handle_simple_format_save(path, format or self._options.get('format'))
+        self._handle_simple_save(path, format or self._options.get('format'))
         return self._df_writer.save(path=path, format=format, mode=mode, partitionBy=partitionBy, **options)
 
     def insertInto(self, tableName: str, overwrite: Optional[bool] = None) -> None:
-        # fixme: impl observe
+        self._handle_simple_save(path=None, table_name=tableName)
         return self._df_writer.insertInto(tableName, overwrite)
 
     def saveAsTable(
@@ -163,27 +165,27 @@ class KensuDataFrameWriter:
         partitionBy: Optional[Union[str, List[str]]] = None,
         **options: "OptionalPrimitiveType",
     ) -> None:
-        # fixme: impl observe
+        self._handle_simple_save(path=None, table_name=name, format=format or self._options.get('format'))
         return self._df_writer.saveAsTable(name=name, format=format, mode=mode, partitionBy=partitionBy, **options)
 
     def json(self, *args, **kwargs) -> None:
-        self._handle_simple_format_save(path=self._path_from_args(args, kwargs), format="json")
+        self._handle_simple_save(path=self._path_from_args(args, kwargs), format="json")
         return self._df_writer.json(*args, **kwargs)
 
     def parquet(self, *args, **kwargs) -> None:
-        self._handle_simple_format_save(path=self._path_from_args(args, kwargs), format="parquet")
+        self._handle_simple_save(path=self._path_from_args(args, kwargs), format="parquet")
         return self._df_writer.parquet(*args, **kwargs)
 
     def text(self, *args, **kwargs) -> None:
-        self._handle_simple_format_save(path=self._path_from_args(args, kwargs), format="text")
+        self._handle_simple_save(path=self._path_from_args(args, kwargs), format="text")
         return self._df_writer.text(*args, **kwargs)
 
     def csv(self, *args, **kwargs) -> None:
-        self._handle_simple_format_save(path=self._path_from_args(args, kwargs), format="csv")
+        self._handle_simple_save(path=self._path_from_args(args, kwargs), format="csv")
         return self._df_writer.csv(*args, **kwargs)
 
     def orc(self, *args, **kwargs) -> None:
-        self._handle_simple_format_save(path=self._path_from_args(args, kwargs), format="orc")
+        self._handle_simple_save(path=self._path_from_args(args, kwargs), format="orc")
         return self._df_writer.orc(*args, **kwargs)
 
     def jdbc(

--- a/kensu/pyspark/KensuDataFrameWriter.py
+++ b/kensu/pyspark/KensuDataFrameWriter.py
@@ -154,7 +154,6 @@ class KensuDataFrameWriter:
         self._handle_simple_format_save(path, format)
         return self._df_writer.save(path=path, format=format, mode=mode, partitionBy=partitionBy, **options)
 
-
     def insertInto(self, tableName: str, overwrite: Optional[bool] = None) -> None:
         # fixme: impl observe
         return self._df_writer.insertInto(tableName, overwrite)
@@ -180,7 +179,7 @@ class KensuDataFrameWriter:
 
     def text(self, path: str, *args, **kwargs) -> None:
         self._handle_simple_format_save(path, format="text")
-        return self._df_writer.text(path=path, compression=compression, lineSep=lineSep)
+        return self._df_writer.text(path=path, *args, **kwargs)
 
     def csv(self, path: str, *args, **kwargs) -> None:
         self._handle_simple_format_save(path, format="csv")

--- a/kensu/pyspark/KensuDataFrameWriter.py
+++ b/kensu/pyspark/KensuDataFrameWriter.py
@@ -125,7 +125,7 @@ class KensuDataFrameWriter:
                             ):
         if path is None:
             path = self._path_from_options()
-        if path is not None:
+        if path is not None or table_name is not None:
             df = self._df
             try:
                 from kensu.pyspark.spark_connector import addOutputObservationsWithRemoteConf

--- a/kensu/pyspark/KensuDataFrameWriter.py
+++ b/kensu/pyspark/KensuDataFrameWriter.py
@@ -203,10 +203,13 @@ class KensuDataFrameWriter:
         mode: Optional[str] = None,
         properties: Optional[Dict[str, str]] = None,
     ) -> None:
-        jdbc_options = self._options.copy()
-        jdbc_options.update(properties or {})
-        jdbc_options.update({'url': url, 'dbtable': table})
-        self._handle_simple_save(
-            jdbc_options=dict([(k, v) for k, v in jdbc_options.items() if isinstance(v, str)]),
-            format="jdbc")
+        # Observe is unsupported for jdbc writes due a known Apache Spark bug, see:
+        # - https://issues.apache.org/jira/browse/SPARK-42034
+        # - https://github.com/apache/spark/pull/39976#issuecomment-1752930380
+        # jdbc_options = self._options.copy()
+        # jdbc_options.update(properties or {})
+        # jdbc_options.update({'url': url, 'dbtable': table})
+        # self._handle_simple_save(
+        #     jdbc_options=dict([(k, v) for k, v in jdbc_options.items() if isinstance(v, str)]),
+        #     format="jdbc")
         return self._df_writer.jdbc(url=url, table=table, mode=mode, properties=properties)

--- a/kensu/pyspark/KensuDataFrameWriter.py
+++ b/kensu/pyspark/KensuDataFrameWriter.py
@@ -39,6 +39,7 @@ class KensuDataFrameWriter:
         self._df_writer = DataFrameWriter(df)  # mutable as we modify df at last moment before write
         self._delayed_calls = []
         self._options = {}
+        self._format = None
 
     # FIXME: implement  __getattr__(self, item) for unknown field names to defer to self._df_writer
 
@@ -73,6 +74,7 @@ class KensuDataFrameWriter:
         return self
 
     def format(self, source: str) -> "KensuDataFrameWriter":
+        self._format = source
         self._delay_fn_call(lambda: self._df_writer.format(source))
         return self
 
@@ -89,9 +91,6 @@ class KensuDataFrameWriter:
 
     def _path_from_options(self):
         return self._options.get('path')
-
-    def _format_from_options(self):
-        return self._options.get('format')
 
     @overload
     def partitionBy(self, *cols: str) -> "KensuDataFrameWriter":
@@ -173,7 +172,7 @@ class KensuDataFrameWriter:
         partitionBy: Optional[Union[str, List[str]]] = None,
         **options: "OptionalPrimitiveType",
     ) -> None:
-        self._handle_simple_save(path, format or self._format_from_options())
+        self._handle_simple_save(path, format or self._format)
         return self._df_writer.save(path=path, format=format, mode=mode, partitionBy=partitionBy, **options)
 
     def insertInto(self, tableName: str, overwrite: Optional[bool] = None) -> None:
@@ -188,7 +187,7 @@ class KensuDataFrameWriter:
         partitionBy: Optional[Union[str, List[str]]] = None,
         **options: "OptionalPrimitiveType",
     ) -> None:
-        self._handle_simple_save(path=None, table_name=name, format=format or self._format_from_options())
+        self._handle_simple_save(path=None, table_name=name, format=format or self._format)
         return self._df_writer.saveAsTable(name=name, format=format, mode=mode, partitionBy=partitionBy, **options)
 
     def json(self, *args, **kwargs) -> None:

--- a/kensu/pyspark/KensuDataFrameWriter.py
+++ b/kensu/pyspark/KensuDataFrameWriter.py
@@ -41,6 +41,16 @@ class KensuDataFrameWriter:
         for fn in self._delayed_calls:
             fn()
 
+    @staticmethod
+    def _path_from_args(args, kwargs):
+        """
+        Allow to call methods:
+        - .parquet("abc.parquet") - args
+        - .parquet(path="abc.parquet") - kwargs
+
+        :return: path for first arg or from kwargs
+        """
+        return kwargs.get('path') or (args and args[0])
 
     def mode(self, saveMode: Optional[str]) -> "KensuDataFrameWriter":
         self._delay_fn_call(lambda: self._df_writer.mode(saveMode))
@@ -153,25 +163,25 @@ class KensuDataFrameWriter:
         # fixme: impl observe
         return self._df_writer.saveAsTable(name=name, format=format, mode=mode, partitionBy=partitionBy, **options)
 
-    def json(self, path: str, *args, **kwargs) -> None:
-        self._handle_simple_format_save(path, format="json")
-        return self._df_writer.json(path, *args, **kwargs)
+    def json(self, *args, **kwargs) -> None:
+        self._handle_simple_format_save(path=self._path_from_args(args, kwargs), format="json")
+        return self._df_writer.json(*args, **kwargs)
 
-    def parquet(self, path: str, *args, **kwargs) -> None:
-        self._handle_simple_format_save(path, format="parquet")
-        return self._df_writer.parquet(path=path, *args, **kwargs)
+    def parquet(self, *args, **kwargs) -> None:
+        self._handle_simple_format_save(path=self._path_from_args(args, kwargs), format="parquet")
+        return self._df_writer.parquet(*args, **kwargs)
 
-    def text(self, path: str, *args, **kwargs) -> None:
-        self._handle_simple_format_save(path, format="text")
-        return self._df_writer.text(path=path, *args, **kwargs)
+    def text(self, *args, **kwargs) -> None:
+        self._handle_simple_format_save(path=self._path_from_args(args, kwargs), format="text")
+        return self._df_writer.text(*args, **kwargs)
 
-    def csv(self, path: str, *args, **kwargs) -> None:
-        self._handle_simple_format_save(path, format="csv")
-        return self._df_writer.csv(path, *args, **kwargs)
+    def csv(self, *args, **kwargs) -> None:
+        self._handle_simple_format_save(path=self._path_from_args(args, kwargs), format="csv")
+        return self._df_writer.csv(*args, **kwargs)
 
-    def orc(self, path: str, *args, **kwargs) -> None:
-        self._handle_simple_format_save(path, format="orc")
-        return self._df_writer.orc(path, *args, **kwargs)
+    def orc(self, *args, **kwargs) -> None:
+        self._handle_simple_format_save(path=self._path_from_args(args, kwargs), format="orc")
+        return self._df_writer.orc(*args, **kwargs)
 
     def jdbc(
         self,

--- a/kensu/pyspark/KensuDataFrameWriter.py
+++ b/kensu/pyspark/KensuDataFrameWriter.py
@@ -127,7 +127,8 @@ class KensuDataFrameWriter:
                 logging.info("KENSU: DataFrameWriter for output path={} format={}, will be automatically updated with Kensu observations via .observe() using remote config if enabled".format(path, format))
                 df = addOutputObservationsWithRemoteConf(df,
                                                          path=path,
-                                                         qualified_table_name=None,
+                                                         table_name=None,
+                                                         format=format,
                                                          compute_count_distinct=kensu_efficient_write_compute_count_distinct)
                 logging.info("KENSU: DataFrameWriter for output path={} format={}, was updated with Kensu observations via .observe() using remote config if enabled".format(path, format))
             except:
@@ -147,7 +148,7 @@ class KensuDataFrameWriter:
         partitionBy: Optional[Union[str, List[str]]] = None,
         **options: "OptionalPrimitiveType",
     ) -> None:
-        self._handle_simple_format_save(path, format)
+        self._handle_simple_format_save(path, format or self._options.get('format'))
         return self._df_writer.save(path=path, format=format, mode=mode, partitionBy=partitionBy, **options)
 
     def insertInto(self, tableName: str, overwrite: Optional[bool] = None) -> None:

--- a/kensu/pyspark/KensuDataFrameWriter.py
+++ b/kensu/pyspark/KensuDataFrameWriter.py
@@ -72,6 +72,12 @@ class KensuDataFrameWriter:
         self._delay_fn_call(lambda: self._df_writer.options(**options))
         return self
 
+    def _path_from_options(self):
+        return self._options.get('path')
+
+    def _format_from_options(self):
+        return self._options.get('format')
+
     @overload
     def partitionBy(self, *cols: str) -> "KensuDataFrameWriter":
         ...
@@ -118,7 +124,7 @@ class KensuDataFrameWriter:
                             table_name: Optional[str] = None
                             ):
         if path is None:
-            path = self._options.get("path", None)
+            path = self._path_from_options()
         if path is not None:
             df = self._df
             try:
@@ -150,7 +156,7 @@ class KensuDataFrameWriter:
         partitionBy: Optional[Union[str, List[str]]] = None,
         **options: "OptionalPrimitiveType",
     ) -> None:
-        self._handle_simple_save(path, format or self._options.get('format'))
+        self._handle_simple_save(path, format or self._format_from_options())
         return self._df_writer.save(path=path, format=format, mode=mode, partitionBy=partitionBy, **options)
 
     def insertInto(self, tableName: str, overwrite: Optional[bool] = None) -> None:
@@ -165,7 +171,7 @@ class KensuDataFrameWriter:
         partitionBy: Optional[Union[str, List[str]]] = None,
         **options: "OptionalPrimitiveType",
     ) -> None:
-        self._handle_simple_save(path=None, table_name=name, format=format or self._options.get('format'))
+        self._handle_simple_save(path=None, table_name=name, format=format or self._format_from_options())
         return self._df_writer.saveAsTable(name=name, format=format, mode=mode, partitionBy=partitionBy, **options)
 
     def json(self, *args, **kwargs) -> None:

--- a/kensu/pyspark/KensuDataFrameWriter.py
+++ b/kensu/pyspark/KensuDataFrameWriter.py
@@ -170,43 +170,23 @@ class KensuDataFrameWriter:
         # fixme: impl observe
         return self._df_writer.saveAsTable(name=name, format=format, mode=mode, partitionBy=partitionBy, **options)
 
-    def json(
-        self,
-        path: str,
-        *args, **kwargs
-    ) -> None:
+    def json(self, path: str, *args, **kwargs) -> None:
         self._handle_simple_format_save(path, format="json")
         return self._df_writer.json(path, *args, **kwargs)
 
-    def parquet(
-        self,
-        path: str,
-        mode: Optional[str] = None,
-        partitionBy: Optional[Union[str, List[str]]] = None,
-        compression: Optional[str] = None,
-    ) -> None:
+    def parquet(self, path: str, *args, **kwargs) -> None:
         self._handle_simple_format_save(path, format="parquet")
-        return self._df_writer.parquet(path=path, mode=mode, partitionBy=partitionBy, compression=compression)
+        return self._df_writer.parquet(path=path, *args, **kwargs)
 
-    def text(
-        self, path: str, compression: Optional[str] = None, lineSep: Optional[str] = None
-    ) -> None:
+    def text(self, path: str, *args, **kwargs) -> None:
         self._handle_simple_format_save(path, format="text")
         return self._df_writer.text(path=path, compression=compression, lineSep=lineSep)
 
-    def csv(
-        self,
-        path: str,
-        *args, **kwargs
-    ) -> None:
+    def csv(self, path: str, *args, **kwargs) -> None:
         self._handle_simple_format_save(path, format="csv")
         return self._df_writer.csv(path, *args, **kwargs)
 
-    def orc(
-        self,
-        path: str,
-        *args, **kwargs
-    ) -> None:
+    def orc(self, path: str, *args, **kwargs) -> None:
         self._handle_simple_format_save(path, format="orc")
         return self._df_writer.orc(path, *args, **kwargs)
 

--- a/kensu/pyspark/KensuDataFrameWriter.py
+++ b/kensu/pyspark/KensuDataFrameWriter.py
@@ -46,7 +46,9 @@ class KensuDataFrameWriter:
         """
         Allow to call methods:
         - .parquet("abc.parquet") - args
+        - .parquet("abc.parquet", mode="overwrite") - args + kwargs
         - .parquet(path="abc.parquet") - kwargs
+        - .parquet(mode="overwrite", path="abc.parquet") - kwargs in weird order - wouldn't work with `def parquet(path, *args, **kwrags)`
 
         :return: path for first arg or from kwargs
         """

--- a/kensu/pyspark/KensuDataFrameWriter.py
+++ b/kensu/pyspark/KensuDataFrameWriter.py
@@ -17,6 +17,20 @@ TupleOrListOfString = Union[List[str], Tuple[str, ...]]
 
 # limitation: partition columns are not supported for LDS name for remote config
 
+# copied from: from pyspark.sql.utils import to_str
+def to_str(value) -> Optional[str]:
+    """
+    A wrapper over str(), but converts bool values to lower case strings.
+    If None is given, just returns None, instead of converting it to string "None".
+    """
+    if isinstance(value, bool):
+        return str(value).lower()
+    elif value is None:
+        return value
+    else:
+        return str(value)
+
+
 class KensuDataFrameWriter:
 
     def __init__(self, df: "DataFrame"):
@@ -63,12 +77,13 @@ class KensuDataFrameWriter:
         return self
 
     def option(self, key: str, value: "OptionalPrimitiveType") -> "KensuDataFrameWriter":
-        self._options[key] = value
+        self._options[key] = to_str(value)
         self._delay_fn_call(lambda: self._df_writer.option(key, to_str(value)))
         return self
 
     def options(self, **options: "OptionalPrimitiveType") -> "KensuDataFrameWriter":
-        self._options.update(options)
+        for k in options:
+            self._options[k] = to_str(options[k])
         self._delay_fn_call(lambda: self._df_writer.options(**options))
         return self
 

--- a/kensu/pyspark/spark_connector.py
+++ b/kensu/pyspark/spark_connector.py
@@ -997,18 +997,21 @@ def addOutputObservations(df,  # type: DataFrame
 @catch_errors_with_default_self
 def addOutputObservationsWithRemoteConf(df,  # type: DataFrame
                                         path=None,  # type: str
-                                        qualified_table_name=None,  # type: str
+                                        table_name=None,  # type: str
+                                        format=None,
                                         compute_count_distinct=False  # not recommended due to likely performance impact
-                          ):
+                                        ):
     # FIXME: looks like we have a repeating pyspark DF -> JVM DF -> pyspark DF pattern here
     spark = df.sql_ctx.sparkSession
     jvm = spark.sparkContext._jvm
     cls = ref_scala_object(jvm, "org.apache.spark.sql.kensu.KensuObserveMetrics")
-    #   def addOutputObservationsWithRemoteConf(df: DataFrame,
+    #   addOutputObservationsWithRemoteConf(df: DataFrame,
     #                                           maybeDsPath: String,
-    #                                           maybeQualifiedTableName: String,
-    #                                           computeCountDistinct: Boolean = false): DataFrame
-    jdf = cls.addOutputObservationsWithRemoteConf(df._jdf, path, qualified_table_name, compute_count_distinct)
+    #                                           maybeTableName: String,
+    #                                           format: String,
+    #                                           computeCountDistinct: Boolean
+    #                                          )
+    jdf = cls.addOutputObservationsWithRemoteConf(df._jdf, path, table_name, format, compute_count_distinct)
     # finally convert Java DataFrame back to python DataFrame
     from pyspark.sql.dataframe import DataFrame
     return DataFrame(jdf, spark)

--- a/kensu/pyspark/spark_connector.py
+++ b/kensu/pyspark/spark_connector.py
@@ -281,7 +281,9 @@ def patch_kensu_df_helpers():
     ])) + [
         ['report_as_kensu_datasource', report_df_as_kensu_datasource()],
         ['report_as_kensu_jdbc_datasource', report_df_as_kensu_jdbc_datasource()],
-        ['report_as_kpi', report_df_as_kpi()]
+        ['report_as_kpi', report_df_as_kpi()],
+        ['write', kensuEfficientWriteProp],
+        ['kensuEfficientWrite', kensuEfficientWriteProp]
     ]
     for fn_name, wrapper_builder in fns_to_patch:
         try:
@@ -1008,6 +1010,21 @@ def addCustomObservationsToOutput(df,  # type: DataFrame
         "ksu_metrics_output_custom_gen{}".format(next_observation_num),
        *exprs
     )
+
+
+from pyspark.sql.dataframe import DataFrameWriter, DataFrame
+
+def kensuEfficientWrite(self) -> DataFrameWriter:
+    """Same as Spark DataFrame.write but adds efficient Kensu Observations"""
+    # FIXME: make compute_count_distinct=False parameterizable
+    # FIXME: implement remote conf -- need output path for that, so will need much more complex wrapper .parquet .csv etc
+    return DataFrameWriter(addOutputObservations(self, compute_count_distinct=False))
+
+
+@property
+def kensuEfficientWriteProp(self) -> DataFrameWriter:
+    """Same as Spark DataFrame.write but adds efficient Kensu Observations"""
+    return kensuEfficientWrite(self)
 
 
 def pyspark_datatype_to_jvm(jvm, pyspark_datatype):

--- a/kensu/pyspark/spark_connector.py
+++ b/kensu/pyspark/spark_connector.py
@@ -1054,7 +1054,7 @@ def make_kensu_efficient_write_fn(kensu_efficient_write_compute_count_distinct=F
         """Returns KensuDataFrameWriter,
         which is mostly same as Spark DataFrame.write, but adds Kensu Observations via .observe()"""
         from kensu.pyspark.KensuDataFrameWriter import KensuDataFrameWriter
-        df_writer = KensuDataFrameWriter(self)
+        df_writer = KensuDataFrameWriter(self, compute_count_distinct=kensu_efficient_write_compute_count_distinct)
         return df_writer
 
     @property

--- a/kensu/pyspark/spark_connector.py
+++ b/kensu/pyspark/spark_connector.py
@@ -998,6 +998,7 @@ def addOutputObservations(df,  # type: DataFrame
 def addOutputObservationsWithRemoteConf(df,  # type: DataFrame
                                         path=None,  # type: str
                                         table_name=None,  # type: str
+                                        jdbc_options=None, # type: Optional[Dict[str, str]]
                                         format=None,
                                         compute_count_distinct=False  # not recommended due to likely performance impact
                                         ):
@@ -1008,10 +1009,11 @@ def addOutputObservationsWithRemoteConf(df,  # type: DataFrame
     #   addOutputObservationsWithRemoteConf(df: DataFrame,
     #                                           maybeDsPath: String,
     #                                           maybeTableName: String,
+    #                                           maybeJdbcOptions: Map[String, String],
     #                                           format: String,
     #                                           computeCountDistinct: Boolean
     #                                          )
-    jdf = cls.addOutputObservationsWithRemoteConf(df._jdf, path, table_name, format, compute_count_distinct)
+    jdf = cls.addOutputObservationsWithRemoteConf(df._jdf, path, table_name, jdbc_options or {}, format, compute_count_distinct)
     # finally convert Java DataFrame back to python DataFrame
     from pyspark.sql.dataframe import DataFrame
     return DataFrame(jdf, spark)

--- a/kensu/pyspark/spark_connector.py
+++ b/kensu/pyspark/spark_connector.py
@@ -1027,7 +1027,6 @@ def make_kensu_efficient_write_fn(kensu_efficient_write_compute_count_distinct=F
 
     def kensu_efficient_write(self):
         """Same as Spark DataFrame.write but adds efficient Kensu Observations"""
-        # FIXME: make observe_compute_count_distinct=False parameterizable
         # FIXME: implement remote conf -- need output path for that, so will need much more complex wrapper .parquet .csv etc
         df = self
         try:

--- a/kensu/pyspark/spark_connector.py
+++ b/kensu/pyspark/spark_connector.py
@@ -1008,7 +1008,7 @@ def addOutputObservationsWithRemoteConf(df,  # type: DataFrame
     #                                           maybeDsPath: String,
     #                                           maybeQualifiedTableName: String,
     #                                           computeCountDistinct: Boolean = false): DataFrame
-    jdf = cls.addOutputObservations(df._jdf, path, qualified_table_name, compute_count_distinct)
+    jdf = cls.addOutputObservationsWithRemoteConf(df._jdf, path, qualified_table_name, compute_count_distinct)
     # finally convert Java DataFrame back to python DataFrame
     from pyspark.sql.dataframe import DataFrame
     return DataFrame(jdf, spark)

--- a/kensu/pyspark/spark_connector.py
+++ b/kensu/pyspark/spark_connector.py
@@ -1009,7 +1009,7 @@ def addOutputObservationsWithRemoteConf(df,  # type: DataFrame
     #   addOutputObservationsWithRemoteConf(df: DataFrame,
     #                                           maybeDsPath: String,
     #                                           maybeTableName: String,
-    #                                           maybeJdbcOptions: Map[String, String],
+    #                                           maybeJdbcOptions: java.util.HashMap[String, String],
     #                                           format: String,
     #                                           computeCountDistinct: Boolean
     #                                          )

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ NAME = artifact_name()
 BUILD_FLAVOR = os.environ["BUILD_FLAVOR"] if "BUILD_FLAVOR" in os.environ else ""
 BUILD_NUMBER = os.environ["BUILD_NUMBER"] if "BUILD_NUMBER" in os.environ else ""
 # https://semver.org/
-VERSION = "2.6.9" + BUILD_FLAVOR + BUILD_NUMBER
+VERSION = "2.7.0" + BUILD_FLAVOR + BUILD_NUMBER
 
 
 


### PR DESCRIPTION
**Implemented: support automatic observe and remote conf  for *DataFrameWriter's* `.write` for full set of DataFrameWriter methods!**
- [x] Basic format writes:
  - `.json(path)`
  - `.parquet(path)`
  - `.text(path)`
  - `.csv(path)`
  - `.options(path="the_path", format="parquet").save()` - if no weird/special connector format is used
  - `.orc(path)`
- [x] when path passed via option and not in method above
- [x] 🔥 `.saveAsTable()` 
- [x] `.insertInto()`
- [ ] 🔥  ~~.jdbc()~~ - dont work due to spark bug
- [ ] 🔥  ~~jdbc via .save()~~ - dont work due to spark bug

**Tests performed for:**

- [x] ✅  .parquet(path)
- [x] `.json()`
- [x] `.orc()`
- [x] `.text()`
- [x] `.csv()`
- [ ] `.format(fmt).save()` - if no weird/special connector format is used
  - [x] `format=parquet`
  - [x] `format=json`
  - [x] `format=orc`
  - [x] `format=text`
  - [x] `format=csv`
  - [ ] `format=delta` (opensource)
  - [ ] limitation - jdbc via .save()? -  currently unsupported
  - [ ] table via save, might be not yet implemented on py side
- [x] 🔥   `.saveAsTable()` - CollectMetrics() added to plan, but observe don't work in spark 3.4.0 (spark bug?)
- [x] ✅  `.insertInto()`
- [x]  🔥  ~~.jdbc()~~ : dont work due to spark bug


**Tested with:**

- [x] spark 3.3.0 - generally works, on databricks with some limitations for table writes
- [x] spark 3.4.0
- [x] spark 3.5.0

