### PR TITLE
use thread local var instead of context.user_data & cleanup

### DIFF
--- a/docs/nuclio/README.md
+++ b/docs/nuclio/README.md
@@ -8,7 +8,6 @@
     - from confluent_kafka import Producer
     + from kensu.nuclio.confluent_kafka import Producer
     ```
-  * add `producer.kensu_set_nuclio_context(context)`
 
 ### Kensu configuration
 

--- a/docs/nuclio/README.md
+++ b/docs/nuclio/README.md
@@ -1,6 +1,6 @@
 # How to use
 
-- `pip install kensu` 
+- install kensu-py where nuclio functions run: `pip install kensu`
 - Add `@track_kensu()` decorator to handler function
 - If using confluent Kafka producer:
   * change your code to import a Kensu wrapper of `confluent_kafka` producer
@@ -29,6 +29,17 @@ Set environment variable `KSU_NUCLIO_REPORTING_INTERVAL_SECONDS=123`.
 
 # Run example nuclio function locally with kafka
 
+The example Nuclio setup consists of the following Kafka `topics` and Nuclio functions (marked `fn:`):
+```
+[topic: raw_events] ==> (fn: ingest-raw-events) ==> [topic: ingested_events{1|2}]
+                    ==> (fn: process-events)    ==> [topic: processed_events{1|2}]
+```
+
+Events sent to the input topic `raw_events` are consumed by the first nuclio function `ingest-raw-events`.
+Subsequently, the events produced in Kafka by this function will be consumed by another nuclio function `process-events` 
+and the final results are written to Kafka topic `processed_events`.
+
+
 ### start Kafka in docker
 
 ```bash
@@ -53,15 +64,5 @@ P.S. only Python 3.8 seemed to work out of the box
 
 ### send some events to kafka
 
-run `./produce_kafka_events.sh`.
-
-this will exec the `_produce_kafka_events.sh` inside Kafka docker which will send some
-sample events to the input topics to be consumed by the first nuclio function `ingest-raw-events`.
-
-Subsequently, the events produced by this function will be consumed by another function `process-events`.
-Thus, we have a dataflow as following:
-
-```
-[topic: raw_events] ==> (fn: ingest-raw-events) ==> [topic: ingested_events{1|2}]
-                    ==> (fn: process-events)    ==> [topic: processed_events{1|2}]
-```
+To produce some events for `raw_events` topic, run `./produce_kafka_events.sh`. 
+This will execute the `_produce_kafka_events.sh` inside Kafka docker.

--- a/docs/nuclio/ingest_raw_events.py
+++ b/docs/nuclio/ingest_raw_events.py
@@ -1,5 +1,6 @@
 import json
 import random
+
 from kensu.nuclio.agent import track_kensu
 
 
@@ -41,7 +42,6 @@ def handler_confluent(context, event):
     # use this instead of: from confluent_kafka import Producer
     from kensu.nuclio.confluent_kafka import Producer
     producer = Producer(conf)
-    producer.kensu_set_nuclio_context(context)
 
     output_data = [
         {

--- a/docs/nuclio/ingest_raw_events.yaml
+++ b/docs/nuclio/ingest_raw_events.yaml
@@ -50,7 +50,7 @@ spec:
   build:
     path: "./ingest_raw_events.py"
     commands:
-      - pip install  --upgrade --extra-index-url https://test.pypi.org/simple/ kensu==2.10.0a178.dev1719763777 confluent-kafka
+      - pip install  --upgrade --extra-index-url https://test.pypi.org/simple/ kensu==2.10.0a0.dev1719908074 confluent-kafka
     noCache: true
     onbuildImage: "quay.io/nuclio/handler-builder-python-onbuild:unstable-arm64"
     runtimeAttributes:

--- a/docs/nuclio/process_events.py
+++ b/docs/nuclio/process_events.py
@@ -41,7 +41,6 @@ def handler_confluent(context, event):
     # use this instead of: from confluent_kafka import Producer
     from kensu.nuclio.confluent_kafka import Producer
     producer = Producer(conf)
-    producer.kensu_set_nuclio_context(context)
 
     output_data = [
         {

--- a/docs/nuclio/process_events.yaml
+++ b/docs/nuclio/process_events.yaml
@@ -51,7 +51,7 @@ spec:
   build:
     path: "./process_events.py"
     commands:
-      - pip install  --upgrade --extra-index-url https://test.pypi.org/simple/ kensu==2.10.0a178.dev1719763777 confluent-kafka
+      - pip install  --upgrade --extra-index-url https://test.pypi.org/simple/ kensu==2.10.0a0.dev1719908074 confluent-kafka
     noCache: true
     onbuildImage: "quay.io/nuclio/handler-builder-python-onbuild:unstable-arm64"
     runtimeAttributes:

--- a/kensu/nuclio/confluent_kafka/__init__.py
+++ b/kensu/nuclio/confluent_kafka/__init__.py
@@ -1,27 +1,21 @@
+import logging
+
 from confluent_kafka import Producer as ConfluentProducer
 from kensu.nuclio.agent import kensu_add_kafka_output
+
 
 class Producer(ConfluentProducer):
     def produce(self, topic, value=None, *args, **kwargs):
         result = super().produce(topic, value, *args, **kwargs)
         try:
-            if not self._kensu_nuclio_context:
-                return result
             kensu_add_kafka_output(
-                context=self._kensu_nuclio_context,
                 topic=topic,
-                cluster_name=self._kensu_stored_config.get('bootstrap.servers') or 'unknown',
+                cluster_name=self._kensu_stored_bootstrap_servers or 'unknown',
                 output_data=value)
-        except Exception:
-            pass
+        except Exception as err:
+            logging.info(f"An issue occurred when reporting Confluent Kafka output to Kensu: {err}")
         return result
-
-    def kensu_set_nuclio_context(self, context):
-        # FIXME: store only needed info - context.user_data
-        self._kensu_nuclio_context = context
 
     def __init__(self, config):
         super().__init__(config)
-        # FIXME: store only needed info - bootstrap.servers
-        self._kensu_stored_config = config
-        self._kensu_nuclio_context = None
+        self._kensu_stored_bootstrap_servers = config.get('bootstrap.servers')


### PR DESCRIPTION
**changes:**
- dont store any mutable state inside `context.user_data`, but use a thread local variable (global var inside `kensu.nuclio.agent` package). This way `context` don't need to be passed to confluent kafka wrapper class.

**context:**
partially based on motivation why nuclio recommends using `context.user_data` https://nuclio.io/docs/latest/concepts/best-practices-and-common-pitfalls/

> Standard multithreading concepts apply also to Nuclio runtimes:
> - Don't share data across workers (your "threads"), to prevent needless locking.
> - Use thread-local storage (TLS) to maintain state rather than global variables.

python doc https://github.com/python/cpython/blob/main/Lib/_threading_local.py